### PR TITLE
Extract property name encoding into MqPropertyNameEncoder

### DIFF
--- a/src/PerformanceTests/TestInfrastructure.cs
+++ b/src/PerformanceTests/TestInfrastructure.cs
@@ -11,6 +11,7 @@ using Transport.IBMMQ;
 
 static partial class TestInfrastructure
 {
+    static readonly IBMMQMessageConverter Converter = new(new MqPropertyNameEncoder());
     static readonly Hashtable ConnectionProperties = BuildConnectionProperties();
 
     internal static partial string GetTestSuiteName() =>
@@ -122,7 +123,7 @@ static partial class TestInfrastructure
             var outgoingMessage = new OutgoingMessage(messageId, headers, body);
             var operation = new UnicastTransportOperation(outgoingMessage, queueName, []);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = Converter.ToNative(operation);
             queue.Put(mqMessage, pmo);
         }
 

--- a/src/Tests/IBMMQMessageConverterTests.cs
+++ b/src/Tests/IBMMQMessageConverterTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 [TestFixture]
 public class IBMMQMessageConverterTests
 {
+    static readonly IBMMQMessageConverter converter = new(new MqPropertyNameEncoder());
     static UnicastTransportOperation CreateOperation(
         Dictionary<string, string> headers = null,
         byte[] body = null,
@@ -36,7 +37,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(properties: properties);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.That(mqMessage.Expiry, Is.EqualTo(300)); // 30s * 10 = 300 tenths-of-seconds
         }
@@ -46,7 +47,7 @@ public class IBMMQMessageConverterTests
         {
             var operation = CreateOperation(properties: []);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.That(mqMessage.Expiry, Is.EqualTo(MQC.MQEI_UNLIMITED));
         }
@@ -56,7 +57,7 @@ public class IBMMQMessageConverterTests
         {
             var operation = CreateOperation();
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.That(mqMessage.Expiry, Is.EqualTo(MQC.MQEI_UNLIMITED));
         }
@@ -71,7 +72,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(properties: properties);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.That(mqMessage.Expiry, Is.EqualTo(36000)); // 3600s * 10
         }
@@ -90,7 +91,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var expected = new byte[24];
             Array.Copy(messageId.ToByteArray(), expected, 16);
@@ -107,7 +108,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var expected = new byte[24];
             Array.Copy(correlationId.ToByteArray(), expected, 16);
@@ -123,7 +124,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.That(mqMessage.ReplyToQueueName, Is.EqualTo("my.reply.queue"));
         }
@@ -134,7 +135,7 @@ public class IBMMQMessageConverterTests
             var body = System.Text.Encoding.UTF8.GetBytes("hello world");
             var operation = CreateOperation(body: body);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             mqMessage.Seek(0);
             var actual = mqMessage.ReadBytes(mqMessage.MessageLength);
@@ -149,7 +150,7 @@ public class IBMMQMessageConverterTests
         public void MessageType_is_datagram()
         {
             var operation = CreateOperation();
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
             Assert.That(mqMessage.MessageType, Is.EqualTo(MQC.MQMT_DATAGRAM));
         }
 
@@ -157,7 +158,7 @@ public class IBMMQMessageConverterTests
         public void Persistence_is_persistent()
         {
             var operation = CreateOperation();
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
             Assert.That(mqMessage.Persistence, Is.EqualTo(MQC.MQPER_PERSISTENT));
         }
 
@@ -169,7 +170,7 @@ public class IBMMQMessageConverterTests
                 { Headers.NonDurableMessage, null }
             };
             var operation = CreateOperation(headers: headers);
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
             Assert.That(mqMessage.Persistence, Is.EqualTo(MQC.MQPER_NOT_PERSISTENT));
         }
 
@@ -177,7 +178,7 @@ public class IBMMQMessageConverterTests
         public void CharacterSet_is_UTF8()
         {
             var operation = CreateOperation();
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
             Assert.That(mqMessage.CharacterSet, Is.EqualTo(MQC.CODESET_UTF));
         }
     }
@@ -194,7 +195,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var value = mqMessage.GetStringProperty("NServiceBus_x002EEnclosedMessageTypes");
             Assert.That(value, Is.EqualTo("MyEvent"));
@@ -209,7 +210,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var value = mqMessage.GetStringProperty("my_x002Dheader");
             Assert.That(value, Is.EqualTo("value"));
@@ -224,7 +225,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var value = mqMessage.GetStringProperty("my__header");
             Assert.That(value, Is.EqualTo("value"));
@@ -244,7 +245,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             var manifest = mqMessage.GetStringProperty("nsbhdrs");
             Assert.That(manifest, Does.Contain("NormalHeader"));
@@ -264,7 +265,7 @@ public class IBMMQMessageConverterTests
             };
             var operation = CreateOperation(headers: headers);
 
-            var mqMessage = IBMMQMessageConverter.ToNative(operation);
+            var mqMessage = converter.ToNative(operation);
 
             Assert.Throws<MQException>(() => mqMessage.GetStringProperty("nsbempty"));
         }

--- a/src/Tests/MqPropertyNameEncoderTests.cs
+++ b/src/Tests/MqPropertyNameEncoderTests.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 [TestFixture]
 public class MqPropertyNameEncoderTests
 {
+    readonly MqPropertyNameEncoder encoder = new();
+
     [TestCase("SimpleHeader", "SimpleHeader")]
     [TestCase("NServiceBus.MessageId", "NServiceBus_x002EMessageId")]
     [TestCase("my-header", "my_x002Dheader")]
@@ -15,7 +17,7 @@ public class MqPropertyNameEncoderTests
     [TestCase("", "")]
     public void Encode(string input, string expected)
     {
-        Assert.That(MqPropertyNameEncoder.Encode(input), Is.EqualTo(expected));
+        Assert.That(encoder.Encode(input), Is.EqualTo(expected));
     }
 
     [TestCase("SimpleHeader", "SimpleHeader")]
@@ -26,7 +28,7 @@ public class MqPropertyNameEncoderTests
     [TestCase("a_b", "a_b")]
     public void Decode(string input, string expected)
     {
-        Assert.That(MqPropertyNameEncoder.Decode(input), Is.EqualTo(expected));
+        Assert.That(encoder.Decode(input), Is.EqualTo(expected));
     }
 
     [TestCase("NServiceBus.MessageId")]
@@ -52,8 +54,8 @@ public class MqPropertyNameEncoderTests
     [TestCase("a_x002E_xNotHex")]
     public void Decode_reverses_Encode(string original)
     {
-        var encoded = MqPropertyNameEncoder.Encode(original);
-        var decoded = MqPropertyNameEncoder.Decode(encoded);
+        var encoded = encoder.Encode(original);
+        var decoded = encoder.Decode(encoded);
         Assert.That(decoded, Is.EqualTo(original));
     }
 }

--- a/src/Tests/MqPropertyNameEncoderTests.cs
+++ b/src/Tests/MqPropertyNameEncoderTests.cs
@@ -1,0 +1,59 @@
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class MqPropertyNameEncoderTests
+{
+    [TestCase("SimpleHeader", "SimpleHeader")]
+    [TestCase("NServiceBus.MessageId", "NServiceBus_x002EMessageId")]
+    [TestCase("my-header", "my_x002Dheader")]
+    [TestCase("my_header", "my__header")]
+    [TestCase("$.diagnostics", "_x0024_x002Ediagnostics")]
+    [TestCase("has space", "has_x0020space")]
+    [TestCase("a.b-c_d", "a_x002Eb_x002Dc__d")]
+    [TestCase("", "")]
+    public void Encode(string input, string expected)
+    {
+        Assert.That(MqPropertyNameEncoder.Encode(input), Is.EqualTo(expected));
+    }
+
+    [TestCase("SimpleHeader", "SimpleHeader")]
+    [TestCase("NServiceBus_x002EMessageId", "NServiceBus.MessageId")]
+    [TestCase("my__header", "my_header")]
+    [TestCase("a_x002Eb_x002Dc__d", "a.b-c_d")]
+    [TestCase("", "")]
+    [TestCase("a_b", "a_b")]
+    public void Decode(string input, string expected)
+    {
+        Assert.That(MqPropertyNameEncoder.Decode(input), Is.EqualTo(expected));
+    }
+
+    [TestCase("NServiceBus.MessageId")]
+    [TestCase("NServiceBus.CorrelationId")]
+    [TestCase("NServiceBus.ConversationId")]
+    [TestCase("NServiceBus.ContentType")]
+    [TestCase("NServiceBus.EnclosedMessageTypes")]
+    [TestCase("NServiceBus.MessageIntent")]
+    [TestCase("NServiceBus.ReplyToAddress")]
+    [TestCase("NServiceBus.TimeSent")]
+    [TestCase("NServiceBus.Version")]
+    [TestCase("NServiceBus.NonDurableMessage")]
+    [TestCase("$.diagnostics.originating.hostid")]
+    [TestCase("traceparent")]
+    [TestCase("SimpleHeader")]
+    [TestCase("my_header")]
+    [TestCase("my-header")]
+    [TestCase("")]
+    [TestCase("Test_xABCD")]
+    [TestCase("Test__Value")]
+    [TestCase("__leading")]
+    [TestCase("trailing__")]
+    [TestCase("a_x002E_xNotHex")]
+    public void Decode_reverses_Encode(string original)
+    {
+        var encoded = MqPropertyNameEncoder.Encode(original);
+        var decoded = MqPropertyNameEncoder.Decode(encoded);
+        Assert.That(decoded, Is.EqualTo(original));
+    }
+}

--- a/src/Transport/IBMMQMessageConverter.cs
+++ b/src/Transport/IBMMQMessageConverter.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-static class IBMMQMessageConverter
+class IBMMQMessageConverter(MqPropertyNameEncoder propertyNameEncoder)
 {
     // IBM MQ silently discards string properties set to "" — they cannot be enumerated via
     // GetPropertyNames nor retrieved via GetStringProperty.  Work around this by:
@@ -13,7 +13,7 @@ static class IBMMQMessageConverter
     const string EmptyHeadersProperty = "nsbempty";
 
 
-    public static byte[] FromNative(MQMessage receivedMessage, Dictionary<string, string> messageHeaders, ref string messageId)
+    public byte[] FromNative(MQMessage receivedMessage, Dictionary<string, string> messageHeaders, ref string messageId)
     {
         byte[] messageBody = receivedMessage.ReadBytes(receivedMessage.MessageLength);
 
@@ -49,7 +49,7 @@ static class IBMMQMessageConverter
             foreach (var escapedName in manifest.Split(','))
             {
                 messageHeaders.Add(
-                    MqPropertyNameEncoder.Decode(escapedName),
+                    propertyNameEncoder.Decode(escapedName),
                     emptySet.Contains(escapedName) ? "" : receivedMessage.GetStringProperty(escapedName));
             }
         }
@@ -62,7 +62,7 @@ static class IBMMQMessageConverter
                 var escapedName = propertyNames.Current!.ToString();
                 if (escapedName != null)
                 {
-                    var originalName = MqPropertyNameEncoder.Decode(escapedName);
+                    var originalName = propertyNameEncoder.Decode(escapedName);
                     messageHeaders.Add(originalName, receivedMessage.GetStringProperty(escapedName));
                 }
             }
@@ -81,7 +81,7 @@ static class IBMMQMessageConverter
     // - Proper property name escaping for all special characters
     // Note: IBMMQHelper needs a QueueManager, but we only use static methods for message creation
     // This is a temporary adapter until we can refactor to pass the QueueManager
-    public static MQMessage ToNative(IOutgoingTransportOperation outgoingTransportOperation)
+    public MQMessage ToNative(IOutgoingTransportOperation outgoingTransportOperation)
     {
         // Temporarily create a message using the same logic as IBMMQHelper.CreateMessage
         // but inline here since we don't have a QueueManager instance
@@ -110,7 +110,7 @@ static class IBMMQMessageConverter
 
         foreach (var header in outgoingMessage.Headers)
         {
-            var escapedKey = MqPropertyNameEncoder.Encode(header.Key);
+            var escapedKey = propertyNameEncoder.Encode(header.Key);
             allNames.Add(escapedKey);
 
             if (string.IsNullOrEmpty(header.Value))

--- a/src/Transport/IBMMQMessageConverter.cs
+++ b/src/Transport/IBMMQMessageConverter.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transport.IBMMQ;
 
-using System.Text.RegularExpressions;
 using IBM.WMQ;
 
 static class IBMMQMessageConverter
@@ -50,7 +49,7 @@ static class IBMMQMessageConverter
             foreach (var escapedName in manifest.Split(','))
             {
                 messageHeaders.Add(
-                    UnescapePropertyName(escapedName),
+                    MqPropertyNameEncoder.Decode(escapedName),
                     emptySet.Contains(escapedName) ? "" : receivedMessage.GetStringProperty(escapedName));
             }
         }
@@ -63,7 +62,7 @@ static class IBMMQMessageConverter
                 var escapedName = propertyNames.Current!.ToString();
                 if (escapedName != null)
                 {
-                    var originalName = UnescapePropertyName(escapedName);
+                    var originalName = MqPropertyNameEncoder.Decode(escapedName);
                     messageHeaders.Add(originalName, receivedMessage.GetStringProperty(escapedName));
                 }
             }
@@ -111,7 +110,7 @@ static class IBMMQMessageConverter
 
         foreach (var header in outgoingMessage.Headers)
         {
-            var escapedKey = EscapePropertyName(header.Key);
+            var escapedKey = MqPropertyNameEncoder.Encode(header.Key);
             allNames.Add(escapedKey);
 
             if (string.IsNullOrEmpty(header.Value))
@@ -182,32 +181,5 @@ static class IBMMQMessageConverter
         {
             message.Expiry = MQC.MQEI_UNLIMITED;
         }
-    }
-
-    // MQ validates property names as Java identifiers: only ASCII letters, digits, and underscores.
-    // Encode underscores as "__", all other non-alphanumeric chars as "_xHHHH".
-    // This handles edge cases like:
-    // - "Test_xABCD" -> escapes to "Test__xABCD" -> unescapes back to "Test_xABCD" ✓
-    // - "Test.Name" -> escapes to "Test_x002EName" -> unescapes back to "Test.Name" ✓
-    // - "Test__Value" -> escapes to "Test____Value" -> unescapes back to "Test__Value" ✓
-    static string EscapePropertyName(string name)
-    {
-        // First, escape existing underscores by doubling them
-        name = name.Replace("_", "__");
-
-        // Then replace all non-alphanumeric characters (excluding underscore) with _xHHHH
-        return Regex.Replace(name, @"[^a-zA-Z0-9_]", match => $"_x{(int)match.Value[0]:X4}");
-    }
-
-    static string UnescapePropertyName(string name)
-    {
-        // First, replace _xHHHH patterns with the corresponding character
-        // Use negative lookbehind (?<!_) to avoid matching _x that's part of __x
-        // (which represents a literal underscore followed by 'x', not an escape sequence)
-        name = Regex.Replace(name, @"(?<!_)_x([0-9A-Fa-f]{4})", match =>
-            ((char)Convert.ToInt32(match.Groups[1].Value, 16)).ToString());
-
-        // Then replace double underscores with single underscores
-        return name.Replace("__", "_");
     }
 }

--- a/src/Transport/IBMMQTransportInfrastructure.cs
+++ b/src/Transport/IBMMQTransportInfrastructure.cs
@@ -71,12 +71,15 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
 
         services
             .AddSingleton(topology)
+            .AddSingleton<MqPropertyNameEncoder>()
+            .AddSingleton<IBMMQMessageConverter>()
             .AddSingleton<CreateQueueManager>(() => new MQQueueManager(queueManagerName, connectionProperties))
             .AddSingleton(new MessagePumpSettings(messageWaitInterval, transactionMode))
             .AddScoped(sp => new MessagePumpWorker(
                 LogManager.GetLogger<MessagePumpWorker>(),
                 sp.GetRequiredService<MessagePumpSettings>(),
                 sp.GetRequiredService<CreateQueueManager>(),
+                sp.GetRequiredService<IBMMQMessageConverter>(),
                 criticalError
             ))
             .AddSingleton<CreateQueueManagerFacade>(qm =>
@@ -92,14 +95,15 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
                 var pool = sp.GetRequiredService<MqConnectionPool>();
                 var createFacade = sp.GetRequiredService<CreateQueueManagerFacade>();
                 var topo = sp.GetRequiredService<TopicTopology>();
+                var converter = sp.GetRequiredService<IBMMQMessageConverter>();
                 var queueCache = sp.GetRequiredService<DestinationCache<MQQueue>>();
                 var topicCache = sp.GetRequiredService<DestinationCache<MQTopic>>();
 
                 return transactionMode switch
                 {
-                    TransportTransactionMode.None => new MessageDispatcher(pool, topo, queueCache, topicCache),
-                    TransportTransactionMode.ReceiveOnly => new MessageDispatcher(pool, topo, queueCache, topicCache),
-                    TransportTransactionMode.SendsAtomicWithReceive => new AtomicMessageDispatcher(pool, topo, createFacade, queueCache, topicCache),
+                    TransportTransactionMode.None => new MessageDispatcher(pool, topo, converter, queueCache, topicCache),
+                    TransportTransactionMode.ReceiveOnly => new MessageDispatcher(pool, topo, converter, queueCache, topicCache),
+                    TransportTransactionMode.SendsAtomicWithReceive => new AtomicMessageDispatcher(pool, topo, createFacade, converter, queueCache, topicCache),
                     TransportTransactionMode.TransactionScope => throw new NotSupportedException("TransactionScope is not supported"),
                     _ => throw new ArgumentOutOfRangeException(nameof(transactionMode), transactionMode, "Unsupported transaction mode")
                 };

--- a/src/Transport/MqPropertyNameEncoder.cs
+++ b/src/Transport/MqPropertyNameEncoder.cs
@@ -1,0 +1,150 @@
+namespace NServiceBus.Transport.IBMMQ;
+
+using System.Collections.Concurrent;
+using System.Text;
+
+/// <summary>
+/// Encodes and decodes MQ message property names using the JMS property name encoding standard.
+/// </summary>
+/// <remarks>
+/// <para>
+/// MQ message properties must have names that are valid Java identifiers (ASCII letters, digits,
+/// and underscores only). The JMS specification defines a standard encoding for property names
+/// that contain characters outside this set: underscores are doubled ("__") and all other
+/// non-identifier characters are encoded as "_xHHHH" where HHHH is the 4-digit uppercase hex
+/// code point.
+/// </para>
+/// <para>
+/// References:
+/// - JMS 2.0 Specification, Section 3.5.1 "Message Properties":
+///   https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#message-properties
+/// - IBM MQ property name restrictions:
+///   https://www.ibm.com/docs/en/ibm-mq/latest?topic=properties-property-names
+/// </para>
+/// </remarks>
+static class MqPropertyNameEncoder
+{
+    // The set of distinct header keys in an NServiceBus system is small and fixed: ~15 built-in
+    // NServiceBus headers plus a handful of custom headers per application. Even with custom
+    // headers, the total number of unique keys is bounded by the application's design, not by
+    // message volume. The cache stabilizes after the first few messages and approaches a 100%
+    // hit rate, so an eviction policy would add complexity without practical benefit.
+    static readonly ConcurrentDictionary<string, string> EncodeCache = new();
+    static readonly ConcurrentDictionary<string, string> DecodeCache = new();
+
+    /// <summary>
+    /// Encodes a property name for use as an MQ message property.
+    /// </summary>
+    /// <remarks>
+    /// Examples:
+    /// - "Test_xABCD" → "Test__xABCD" → decodes back to "Test_xABCD"
+    /// - "Test.Name" → "Test_x002EName" → decodes back to "Test.Name"
+    /// - "Test__Value" → "Test____Value" → decodes back to "Test__Value"
+    /// </remarks>
+    public static string Encode(string name) => EncodeCache.GetOrAdd(name, DoEncode);
+
+    /// <summary>
+    /// Decodes an MQ property name back to the original property name.
+    /// </summary>
+    public static string Decode(string name) => DecodeCache.GetOrAdd(name, DoDecode);
+
+    static string DoEncode(string name)
+    {
+        // Fast path: check if encoding is needed (no underscores and no non-identifier chars)
+        var needsEncoding = false;
+        foreach (var c in name)
+        {
+            if (c == '_' || !char.IsAsciiLetterOrDigit(c))
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding)
+        {
+            return name;
+        }
+
+        var sb = new StringBuilder(name.Length + 16);
+        foreach (var c in name)
+        {
+            if (c == '_')
+            {
+                sb.Append("__");
+            }
+            else if (char.IsAsciiLetterOrDigit(c))
+            {
+                sb.Append(c);
+            }
+            else
+            {
+                sb.Append("_x");
+                var hex = (int)c;
+                sb.Append(HexChars[(hex >> 12) & 0xF]);
+                sb.Append(HexChars[(hex >> 8) & 0xF]);
+                sb.Append(HexChars[(hex >> 4) & 0xF]);
+                sb.Append(HexChars[hex & 0xF]);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    static string DoDecode(string name)
+    {
+        // Fast path: if no escape sequences present
+        if (name.IndexOf('_') < 0)
+        {
+            return name;
+        }
+
+        var sb = new StringBuilder(name.Length);
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (name[i] == '_')
+            {
+                if (i + 1 < name.Length && name[i + 1] == '_')
+                {
+                    // Double underscore → single underscore
+                    sb.Append('_');
+                    i++;
+                }
+                else if (i + 5 < name.Length && name[i + 1] == 'x'
+                                              && IsHexDigit(name[i + 2]) && IsHexDigit(name[i + 3])
+                                              && IsHexDigit(name[i + 4]) && IsHexDigit(name[i + 5]))
+                {
+                    // _xHHHH → char
+                    var hex = (HexValue(name[i + 2]) << 12)
+                              | (HexValue(name[i + 3]) << 8)
+                              | (HexValue(name[i + 4]) << 4)
+                              | HexValue(name[i + 5]);
+                    sb.Append((char)hex);
+                    i += 5;
+                }
+                else
+                {
+                    sb.Append('_');
+                }
+            }
+            else
+            {
+                sb.Append(name[i]);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    const string HexChars = "0123456789ABCDEF";
+
+    static bool IsHexDigit(char c) => c is (>= '0' and <= '9') or (>= 'A' and <= 'F') or (>= 'a' and <= 'f');
+
+    static int HexValue(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'A' and <= 'F' => c - 'A' + 10,
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        _ => 0
+    };
+}

--- a/src/Transport/MqPropertyNameEncoder.cs
+++ b/src/Transport/MqPropertyNameEncoder.cs
@@ -22,15 +22,15 @@ using System.Text;
 ///   https://www.ibm.com/docs/en/ibm-mq/latest?topic=properties-property-names
 /// </para>
 /// </remarks>
-static class MqPropertyNameEncoder
+class MqPropertyNameEncoder
 {
     // The set of distinct header keys in an NServiceBus system is small and fixed: ~15 built-in
     // NServiceBus headers plus a handful of custom headers per application. Even with custom
     // headers, the total number of unique keys is bounded by the application's design, not by
     // message volume. The cache stabilizes after the first few messages and approaches a 100%
     // hit rate, so an eviction policy would add complexity without practical benefit.
-    static readonly ConcurrentDictionary<string, string> EncodeCache = new();
-    static readonly ConcurrentDictionary<string, string> DecodeCache = new();
+    readonly ConcurrentDictionary<string, string> EncodeCache = new();
+    readonly ConcurrentDictionary<string, string> DecodeCache = new();
 
     /// <summary>
     /// Encodes a property name for use as an MQ message property.
@@ -41,12 +41,12 @@ static class MqPropertyNameEncoder
     /// - "Test.Name" → "Test_x002EName" → decodes back to "Test.Name"
     /// - "Test__Value" → "Test____Value" → decodes back to "Test__Value"
     /// </remarks>
-    public static string Encode(string name) => EncodeCache.GetOrAdd(name, DoEncode);
+    public string Encode(string name) => EncodeCache.GetOrAdd(name, DoEncode);
 
     /// <summary>
     /// Decodes an MQ property name back to the original property name.
     /// </summary>
-    public static string Decode(string name) => DecodeCache.GetOrAdd(name, DoDecode);
+    public string Decode(string name) => DecodeCache.GetOrAdd(name, DoDecode);
 
     static string DoEncode(string name)
     {

--- a/src/Transport/Receiving/MessagePumpWorker.cs
+++ b/src/Transport/Receiving/MessagePumpWorker.cs
@@ -10,6 +10,7 @@ sealed class MessagePumpWorker(
     ILog log,
     MessagePumpSettings settings,
     CreateQueueManager createConnection,
+    IBMMQMessageConverter messageConverter,
     Action<string, Exception, CancellationToken> criticalError
 ) : IAsyncDisposable
 {
@@ -164,7 +165,7 @@ sealed class MessagePumpWorker(
                     try
                     {
                         queue.Get(receivedMessage, getOptions);
-                        messageBody = IBMMQMessageConverter.FromNative(receivedMessage, messageHeaders, ref messageId);
+                        messageBody = messageConverter.FromNative(receivedMessage, messageHeaders, ref messageId);
                         originalHeaders = new Dictionary<string, string>(messageHeaders);
 
                         if (isDebugEnabled)

--- a/src/Transport/Sending/AtomicMessageDispatcher.cs
+++ b/src/Transport/Sending/AtomicMessageDispatcher.cs
@@ -2,8 +2,8 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-sealed class AtomicMessageDispatcher(MqConnectionPool pool, TopicTopology topology, CreateQueueManagerFacade createFacade, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache)
-    : MessageDispatcher(pool, topology, queueCache, topicCache)
+sealed class AtomicMessageDispatcher(MqConnectionPool pool, TopicTopology topology, CreateQueueManagerFacade createFacade, IBMMQMessageConverter messageConverter, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache)
+    : MessageDispatcher(pool, topology, messageConverter, queueCache, topicCache)
 {
     public override Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
     {

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache) : IMessageDispatcher
+class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQMessageConverter messageConverter, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache) : IMessageDispatcher
 {
     protected readonly record struct DispatchContext(MqQueueManagerFacade Facade, int PutOptions);
 
@@ -16,7 +16,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, Desti
             foreach (var operation in outgoingMessages.UnicastTransportOperations)
             {
                 var queue = queueCache.GetOrAdd(operation.Destination, context.Facade.AccessSendQueue);
-                var message = IBMMQMessageConverter.ToNative(operation);
+                var message = messageConverter.ToNative(operation);
 
                 try
                 {
@@ -37,7 +37,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, Desti
                         context.Facade.EnsureTopic(destination.TopicName, destination.TopicString));
 
                     // Message cannot be re-used, is modified by .Put(..)
-                    var message = IBMMQMessageConverter.ToNative(operation);
+                    var message = messageConverter.ToNative(operation);
 
                     try
                     {
@@ -67,7 +67,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, Desti
 
     protected void ReturnToPool(MqQueueManagerFacade facade) => sendPool.Return(facade);
 
-    protected static void DispatchUnicast(UnicastTransportOperation operation, Dictionary<string, MQQueue> queues, DispatchContext context)
+    protected void DispatchUnicast(UnicastTransportOperation operation, Dictionary<string, MQQueue> queues, DispatchContext context)
     {
         if (!queues.TryGetValue(operation.Destination, out var queue))
         {
@@ -75,7 +75,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, Desti
             queues[operation.Destination] = queue;
         }
 
-        var message = IBMMQMessageConverter.ToNative(operation);
+        var message = messageConverter.ToNative(operation);
         queue.Put(message, new MQPutMessageOptions { Options = context.PutOptions });
     }
 
@@ -91,8 +91,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, Desti
                 topics[destination.TopicName] = topic;
             }
 
-            // Message cannot be re-used, is modified by .Put(..)
-            var message = IBMMQMessageConverter.ToNative(operation);
+            var message = messageConverter.ToNative(operation);
             topic.Put(message, putOptions);
         }
     }


### PR DESCRIPTION
Move MQ property name escape/unescape logic from IBMMQMessageConverter into a dedicated MqPropertyNameEncoder class with Encode/Decode methods.

Replaces regex-based encoding with manual char-by-char implementation and adds a ConcurrentDictionary cache. The cache is unbounded by design: NServiceBus header keys are a small, fixed set (~15 built-in + a few custom per application) so the cache stabilizes after the first message.