### PR TITLE
MQTopic and MQQueue objects cannot be shared between MQQueueManager

### DIFF
--- a/src/Transport/IBMMQTransportInfrastructure.cs
+++ b/src/Transport/IBMMQTransportInfrastructure.cs
@@ -83,10 +83,10 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
                 criticalError
             ))
             .AddSingleton<CreateQueueManagerFacade>(qm =>
-                new MqQueueManagerFacade(qm, resourceNameFormatter, LogManager.GetLogger<MqQueueManagerFacade>()))
+                new MqQueueManagerFacade(LogManager.GetLogger<MqQueueManagerFacade>(), qm, resourceNameFormatter))
             .AddSingleton(new MqConnectionPool(
                 () => new MQQueueManager(queueManagerName, connectionProperties),
-                qm => new MqQueueManagerFacade(qm, resourceNameFormatter, LogManager.GetLogger<MqQueueManagerFacade>()),
+                qm => new MqQueueManagerFacade(LogManager.GetLogger<MqQueueManagerFacade>(), qm, resourceNameFormatter),
                 Environment.ProcessorCount))
             .AddSingleton<IMessageDispatcher>(sp =>
             {

--- a/src/Transport/IBMMQTransportInfrastructure.cs
+++ b/src/Transport/IBMMQTransportInfrastructure.cs
@@ -83,10 +83,10 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
                 criticalError
             ))
             .AddSingleton<CreateQueueManagerFacade>(qm =>
-                new MqQueueManagerFacade(qm, resourceNameFormatter))
+                new MqQueueManagerFacade(qm, resourceNameFormatter, LogManager.GetLogger<MqQueueManagerFacade>()))
             .AddSingleton(new MqConnectionPool(
                 () => new MQQueueManager(queueManagerName, connectionProperties),
-                qm => new MqQueueManagerFacade(qm, resourceNameFormatter),
+                qm => new MqQueueManagerFacade(qm, resourceNameFormatter, LogManager.GetLogger<MqQueueManagerFacade>()),
                 Environment.ProcessorCount))
             .AddSingleton<IMessageDispatcher>(sp =>
             {

--- a/src/Transport/IBMMQTransportInfrastructure.cs
+++ b/src/Transport/IBMMQTransportInfrastructure.cs
@@ -88,22 +88,18 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
                 () => new MQQueueManager(queueManagerName, connectionProperties),
                 qm => new MqQueueManagerFacade(qm, resourceNameFormatter),
                 Environment.ProcessorCount))
-            .AddSingleton(new DestinationCache<MQQueue>(100))
-            .AddSingleton(new DestinationCache<MQTopic>(100))
             .AddSingleton<IMessageDispatcher>(sp =>
             {
                 var pool = sp.GetRequiredService<MqConnectionPool>();
                 var createFacade = sp.GetRequiredService<CreateQueueManagerFacade>();
                 var topo = sp.GetRequiredService<TopicTopology>();
                 var converter = sp.GetRequiredService<IBMMQMessageConverter>();
-                var queueCache = sp.GetRequiredService<DestinationCache<MQQueue>>();
-                var topicCache = sp.GetRequiredService<DestinationCache<MQTopic>>();
 
                 return transactionMode switch
                 {
-                    TransportTransactionMode.None => new MessageDispatcher(pool, topo, converter, queueCache, topicCache),
-                    TransportTransactionMode.ReceiveOnly => new MessageDispatcher(pool, topo, converter, queueCache, topicCache),
-                    TransportTransactionMode.SendsAtomicWithReceive => new AtomicMessageDispatcher(pool, topo, createFacade, converter, queueCache, topicCache),
+                    TransportTransactionMode.None => new MessageDispatcher(pool, topo, converter),
+                    TransportTransactionMode.ReceiveOnly => new MessageDispatcher(pool, topo, converter),
+                    TransportTransactionMode.SendsAtomicWithReceive => new AtomicMessageDispatcher(pool, topo, createFacade, converter),
                     TransportTransactionMode.TransactionScope => throw new NotSupportedException("TransactionScope is not supported"),
                     _ => throw new ArgumentOutOfRangeException(nameof(transactionMode), transactionMode, "Unsupported transaction mode")
                 };

--- a/src/Transport/MqQueueManagerFacade.cs
+++ b/src/Transport/MqQueueManagerFacade.cs
@@ -5,13 +5,28 @@ using IBM.WMQ.PCF;
 
 class MqQueueManagerFacade(MQQueueManager queueManager, SanitizeResourceName resourceNameFormatter)
 {
+    readonly DestinationCache<MQQueue> queueCache = new(100);
+    readonly DestinationCache<MQTopic> topicCache = new(100);
+
     public void Disconnect()
     {
+        queueCache.Dispose();
+        topicCache.Dispose();
+
         using (queueManager)
         {
             queueManager.Disconnect();
         }
     }
+
+    public MQQueue GetOrOpenSendQueue(string name) => queueCache.GetOrAdd(name, AccessSendQueue);
+
+    public MQTopic GetOrEnsureTopic(string topicName, string topicString) =>
+        topicCache.GetOrAdd(topicName, _ => EnsureTopic(topicName, topicString));
+
+    public void EvictSendQueue(string name) => queueCache.Evict(name);
+
+    public void EvictTopic(string name) => topicCache.Evict(name);
 
     public MQQueue AccessSendQueue(string name)
     {
@@ -37,6 +52,12 @@ class MqQueueManagerFacade(MQQueueManager queueManager, SanitizeResourceName res
         }
         catch (MQException)
         {
+            // IBM MQ does not return a single distinguishable reason code for
+            // "topic object does not exist"; the error depends on queue manager
+            // configuration. Optimistically attempt to create the admin object
+            // on any failure. CreateTopicOrThrow is idempotent (ignores
+            // "already exists") and translates authorization errors into a
+            // descriptive exception.
             CreateTopicOrThrow(topicName, topicString);
             return AccessTopic(topicString);
         }

--- a/src/Transport/MqQueueManagerFacade.cs
+++ b/src/Transport/MqQueueManagerFacade.cs
@@ -4,7 +4,11 @@ using IBM.WMQ;
 using IBM.WMQ.PCF;
 using Logging;
 
-class MqQueueManagerFacade(MQQueueManager queueManager, SanitizeResourceName resourceNameFormatter, ILog log)
+class MqQueueManagerFacade(
+    ILog log,
+    MQQueueManager queueManager,
+    SanitizeResourceName resourceNameFormatter
+    )
 {
     readonly DestinationCache<MQQueue> queueCache = new(log, 100);
     readonly DestinationCache<MQTopic> topicCache = new(log, 100);

--- a/src/Transport/MqQueueManagerFacade.cs
+++ b/src/Transport/MqQueueManagerFacade.cs
@@ -2,11 +2,12 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 using IBM.WMQ.PCF;
+using Logging;
 
-class MqQueueManagerFacade(MQQueueManager queueManager, SanitizeResourceName resourceNameFormatter)
+class MqQueueManagerFacade(MQQueueManager queueManager, SanitizeResourceName resourceNameFormatter, ILog log)
 {
-    readonly DestinationCache<MQQueue> queueCache = new(100);
-    readonly DestinationCache<MQTopic> topicCache = new(100);
+    readonly DestinationCache<MQQueue> queueCache = new(log, 100);
+    readonly DestinationCache<MQTopic> topicCache = new(log, 100);
 
     public void Disconnect()
     {

--- a/src/Transport/Sending/AtomicMessageDispatcher.cs
+++ b/src/Transport/Sending/AtomicMessageDispatcher.cs
@@ -2,8 +2,8 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-sealed class AtomicMessageDispatcher(MqConnectionPool pool, TopicTopology topology, CreateQueueManagerFacade createFacade, IBMMQMessageConverter messageConverter, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache)
-    : MessageDispatcher(pool, topology, messageConverter, queueCache, topicCache)
+sealed class AtomicMessageDispatcher(MqConnectionPool pool, TopicTopology topology, CreateQueueManagerFacade createFacade, IBMMQMessageConverter messageConverter)
+    : MessageDispatcher(pool, topology, messageConverter)
 {
     public override Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
     {

--- a/src/Transport/Sending/AtomicMessageDispatcher.cs
+++ b/src/Transport/Sending/AtomicMessageDispatcher.cs
@@ -2,8 +2,12 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-sealed class AtomicMessageDispatcher(MqConnectionPool pool, TopicTopology topology, CreateQueueManagerFacade createFacade, IBMMQMessageConverter messageConverter)
-    : MessageDispatcher(pool, topology, messageConverter)
+sealed class AtomicMessageDispatcher(
+    MqConnectionPool pool,
+    TopicTopology topology,
+    CreateQueueManagerFacade createFacade,
+    IBMMQMessageConverter messageConverter
+) : MessageDispatcher(pool, topology, messageConverter)
 {
     public override Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
     {

--- a/src/Transport/Sending/DestinationCache.cs
+++ b/src/Transport/Sending/DestinationCache.cs
@@ -1,29 +1,26 @@
 namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
+using Logging;
 
-sealed class DestinationCache<T> : IDisposable where T : MQDestination
+sealed class DestinationCache<T>(ILog log, int capacity) : IDisposable where T : MQDestination
 {
-    readonly Lock _lock = new();
-    readonly Dictionary<string, LinkedListNode<(string Key, T Value)>> _map;
-    readonly LinkedList<(string Key, T Value)> _list = new();
-    readonly int _capacity;
-
-    public DestinationCache(int capacity)
-    {
-        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
-        _capacity = capacity;
-        _map = new(capacity);
-    }
+    readonly bool isDebugEnabled = log.IsDebugEnabled;
+    readonly Lock gate = new();
+    readonly Dictionary<string, LinkedListNode<(string Key, T Value)>> map = new(capacity);
+    readonly LinkedList<(string Key, T Value)> list = new();
+    bool disposed;
 
     public T GetOrAdd(string key, Func<string, T> factory)
     {
-        lock (_lock)
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        lock (gate)
         {
-            if (_map.TryGetValue(key, out var node))
+            if (map.TryGetValue(key, out var node))
             {
-                _list.Remove(node);
-                _list.AddFirst(node);
+                list.Remove(node);
+                list.AddFirst(node);
                 return node.Value.Value;
             }
         }
@@ -32,39 +29,39 @@ sealed class DestinationCache<T> : IDisposable where T : MQDestination
         // concurrent dispatchers during MQ network round-trips.
         var value = factory(key);
 
-        lock (_lock)
+        lock (gate)
         {
             // Another thread may have added the same key while we
-            // were outside the lock — use that entry instead.
-            if (_map.TryGetValue(key, out var existing))
+            // were outside the lock, so use that entry instead.
+            if (map.TryGetValue(key, out var existing))
             {
-                _list.Remove(existing);
-                _list.AddFirst(existing);
+                list.Remove(existing);
+                list.AddFirst(existing);
                 CloseQuietly(value);
                 return existing.Value.Value;
             }
 
-            if (_list.Count >= _capacity)
+            if (list.Count >= capacity)
             {
-                var lru = _list.Last!;
-                _list.RemoveLast();
-                _map.Remove(lru.Value.Key);
+                var lru = list.Last!;
+                list.RemoveLast();
+                map.Remove(lru.Value.Key);
                 CloseQuietly(lru.Value.Value);
             }
 
-            var newNode = _list.AddFirst((key, value));
-            _map[key] = newNode;
+            var newNode = list.AddFirst((key, value));
+            map[key] = newNode;
             return value;
         }
     }
 
     public void Evict(string key)
     {
-        lock (_lock)
+        lock (gate)
         {
-            if (_map.Remove(key, out var node))
+            if (map.Remove(key, out var node))
             {
-                _list.Remove(node);
+                list.Remove(node);
                 CloseQuietly(node.Value.Value);
             }
         }
@@ -72,27 +69,38 @@ sealed class DestinationCache<T> : IDisposable where T : MQDestination
 
     public void Dispose()
     {
-        lock (_lock)
+        lock (gate)
         {
-            foreach (var (_, value) in _list)
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+
+            foreach (var (_, value) in list)
             {
                 CloseQuietly(value);
             }
 
-            _list.Clear();
-            _map.Clear();
+            list.Clear();
+            map.Clear();
         }
     }
 
-    static void CloseQuietly(T destination)
+    void CloseQuietly(T destination)
     {
         try
         {
             destination.Close();
         }
-        catch (MQException)
+        catch (MQException ex)
         {
-            // Connection may already be closed during shutdown
+            if (isDebugEnabled)
+            {
+                // Handle may be stale if the underlying connection was closed
+                log.Debug($"Failed to close {typeof(T).Name} handle: reason code {ex.ReasonCode}", ex);
+            }
         }
     }
 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -2,7 +2,11 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQMessageConverter messageConverter) : IMessageDispatcher
+class MessageDispatcher(
+    MqConnectionPool sendPool,
+    TopicTopology topology,
+    IBMMQMessageConverter messageConverter
+) : IMessageDispatcher
 {
     protected readonly record struct DispatchContext(MqQueueManagerFacade Facade, int PutOptions);
 
@@ -90,7 +94,6 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
                 topics[destination.TopicName] = topic;
             }
 
-            // Message cannot be re-used, is modified by .Put(..)
             var message = messageConverter.ToNative(operation);
             topic.Put(message, putOptions);
         }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using IBM.WMQ;
 
-class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQMessageConverter messageConverter, DestinationCache<MQQueue> queueCache, DestinationCache<MQTopic> topicCache) : IMessageDispatcher
+class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQMessageConverter messageConverter) : IMessageDispatcher
 {
     protected readonly record struct DispatchContext(MqQueueManagerFacade Facade, int PutOptions);
 
@@ -15,7 +15,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
         {
             foreach (var operation in outgoingMessages.UnicastTransportOperations)
             {
-                var queue = queueCache.GetOrAdd(operation.Destination, context.Facade.AccessSendQueue);
+                var queue = context.Facade.GetOrOpenSendQueue(operation.Destination);
                 var message = messageConverter.ToNative(operation);
 
                 try
@@ -24,7 +24,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
                 }
                 catch (MQException)
                 {
-                    queueCache.Evict(operation.Destination);
+                    context.Facade.EvictSendQueue(operation.Destination);
                     throw;
                 }
             }
@@ -33,8 +33,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
             {
                 foreach (var destination in topology.GetPublishDestinations(operation.MessageType))
                 {
-                    var topic = topicCache.GetOrAdd(destination.TopicName, _ =>
-                        context.Facade.EnsureTopic(destination.TopicName, destination.TopicString));
+                    var topic = context.Facade.GetOrEnsureTopic(destination.TopicName, destination.TopicString);
 
                     // Message cannot be re-used, is modified by .Put(..)
                     var message = messageConverter.ToNative(operation);
@@ -45,7 +44,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
                     }
                     catch (MQException)
                     {
-                        topicCache.Evict(destination.TopicName);
+                        context.Facade.EvictTopic(destination.TopicName);
                         throw;
                     }
                 }
@@ -91,6 +90,7 @@ class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQ
                 topics[destination.TopicName] = topic;
             }
 
+            // Message cannot be re-used, is modified by .Put(..)
             var message = messageConverter.ToNative(operation);
             topic.Put(message, putOptions);
         }


### PR DESCRIPTION
Summary

  - Fix destination handle caches to be per-connection instead of singleton, preventing cross-connection handle use that would cause MQRC_HOBJ_ERROR at runtime
  - Improve DestinationCache quality: camelCase field naming, ObjectDisposedException guard, debug logging on failed handle close

  Design

  MQ handles are bound to the MQQueueManager connection that created them. The previous implementation registered DestinationCache<MQQueue> and DestinationCache<MQTopic> as singletons shared across all pooled connections. When the connection pool rotated connections between dispatches, cached handles from one connection would be served to a dispatch using a different connection.

  Each MqQueueManagerFacade now owns its own cache pair, tying handle lifetime to the connection that created them. Disconnect() disposes both caches before disconnecting. The singleton registrations and cache constructor parameters on the dispatchers have been removed.

  Test plan

  - Verify send operations work correctly when the connection pool has multiple connections (Environment.ProcessorCount > 1)
  - Verify handles are properly closed on facade disconnect
  - Verify CloseQuietly logs at debug level instead of silently swallowing