### PR TITLE
Switch to NuGet Central Package Management

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.IBMMQ.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.IBMMQ.AcceptanceTests.csproj
@@ -6,16 +6,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="GitHubActionsTestLogger" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="NUnit3TestAdapter" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.0" GeneratePathProperty="true" />
-        <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
+        <PackageReference Include="NServiceBus.AcceptanceTests.Sources" GeneratePathProperty="true" />
+        <PackageReference Include="System.IO.Hashing" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Benchmarks/NServiceBus.Transport.IBMMQ.Benchmarks.csproj
+++ b/src/Benchmarks/NServiceBus.Transport.IBMMQ.Benchmarks.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="IBMMQDotnetClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
+    <PackageReference Include="IBMMQDotnetClient" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
   </ItemGroup>
 
 </Project>

--- a/src/CommandLineTests/NServiceBus.Transport.IBMMQ.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transport.IBMMQ.CommandLine.Tests.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,29 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
+    <PackageVersion Include="IBMMQDotnetClient" Version="9.4.5" />
+    <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="NServiceBus" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus.PerformanceTests.Sources" Version="1.0.0-alpha.2" />
+    <PackageVersion Include="NServiceBus.Testing" Version="10.0.1" />
+    <PackageVersion Include="NServiceBus.TransportTests.Sources" Version="10.1.0" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="Particular.Approvals" Version="2.0.1" />
+    <PackageVersion Include="Particular.Packaging" Version="4.5.0" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/PerformanceTests/NServiceBus.Transport.IBMMQ.PerformanceTests.csproj
+++ b/src/PerformanceTests/NServiceBus.Transport.IBMMQ.PerformanceTests.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
-    <PackageReference Include="NServiceBus.PerformanceTests.Sources" Version="1.0.0-alpha.2" />
-    <PackageReference Include="System.CommandLine" Version="2.0.5" />
-    <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
+    <PackageReference Include="IBMMQDotnetClient" />
+    <PackageReference Include="NServiceBus.PerformanceTests.Sources" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/NServiceBus.Transport.IBMMQ.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.IBMMQ.Tests.csproj
@@ -11,17 +11,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="GitHubActionsTestLogger" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="NUnit3TestAdapter" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NServiceBus.Testing" Version="10.0.1" />
-        <PackageReference Include="Particular.Approvals" Version="2.0.1" />
-        <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
+        <PackageReference Include="NServiceBus.Testing" />
+        <PackageReference Include="Particular.Approvals" />
+        <PackageReference Include="PublicApiGenerator" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Transport/NServiceBus.Transport.IBMMQ.csproj
+++ b/src/Transport/NServiceBus.Transport.IBMMQ.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" AutomaticVersionRange="false" />
-    <PackageReference Include="NServiceBus" Version="10.1.0" />
+    <PackageReference Include="IBMMQDotnetClient" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" AutomaticVersionRange="false" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TransportTests/NServiceBus.Transport.IBMMQ.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.IBMMQ.TransportTests.csproj
@@ -5,15 +5,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="GitHubActionsTestLogger" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="NUnit3TestAdapter" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="NServiceBus.TransportTests.Sources" Version="10.1.0" />
+      <PackageReference Include="NServiceBus.TransportTests.Sources" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `Directory.Packages.props` to centralize all 19 package versions in a single file
- Removes inline `Version` attributes from all 8 csproj files
- Preserves non-version attributes (`PrivateAssets`, `GeneratePathProperty`, `AutomaticVersionRange`)

## Test plan
- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds with 0 warnings, 0 errors