### PR TITLE
Mark benchmark and performance test projects as non-packable

### DIFF
--- a/src/Benchmarks/NServiceBus.Transport.IBMMQ.Benchmarks.csproj
+++ b/src/Benchmarks/NServiceBus.Transport.IBMMQ.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/PerformanceTests/NServiceBus.Transport.IBMMQ.PerformanceTests.csproj
+++ b/src/PerformanceTests/NServiceBus.Transport.IBMMQ.PerformanceTests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Add `<IsPackable>false</IsPackable>` to Benchmarks and PerformanceTests project files to prevent them from being packed into NuGet packages