### PR TITLE
Lift native MQ message properties to NServiceBus headers

### DIFF
--- a/src/Tests/IBMMQMessageConverterTests.cs
+++ b/src/Tests/IBMMQMessageConverterTests.cs
@@ -117,6 +117,76 @@ public class IBMMQMessageConverterTests
         }
 
         [Test]
+        public void Sets_MessageId_from_hex_string()
+        {
+            var nativeId = new byte[24];
+            Array.Copy(Guid.NewGuid().ToByteArray(), nativeId, 16);
+            var hexId = Convert.ToHexString(nativeId);
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, hexId }
+            };
+            var operation = CreateOperation(headers: headers);
+
+            var mqMessage = converter.ToNative(operation);
+
+            Assert.That(mqMessage.MessageId, Is.EqualTo(nativeId));
+        }
+
+        [Test]
+        public void Sets_CorrelationId_from_hex_string()
+        {
+            var nativeCorrel = new byte[24];
+            Array.Copy(Guid.NewGuid().ToByteArray(), nativeCorrel, 16);
+            var hexCorrel = Convert.ToHexString(nativeCorrel);
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.CorrelationId, hexCorrel }
+            };
+            var operation = CreateOperation(headers: headers);
+
+            var mqMessage = converter.ToNative(operation);
+
+            Assert.That(mqMessage.CorrelationId, Is.EqualTo(nativeCorrel));
+        }
+
+        [Test]
+        public void Non_guid_non_hex_MessageId_does_not_set_native_field()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, "not-a-guid-or-hex" }
+            };
+            var operation = CreateOperation(headers: headers);
+
+            var mqMessage = converter.ToNative(operation);
+
+            Assert.That(mqMessage.MessageId, Is.EqualTo(new byte[24]));
+        }
+
+        [Test]
+        public void Native_MessageId_round_trips_through_hex()
+        {
+            // Simulate receiving a native message, then forwarding it
+            var originalId = new byte[24];
+            new Random(42).NextBytes(originalId);
+
+            var incoming = new MQMessage { MessageId = originalId };
+            incoming.Write(System.Text.Encoding.UTF8.GetBytes("test"));
+            incoming.Seek(0);
+
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(incoming, receivedHeaders, ref messageId);
+
+            // Forward: use the lifted header to set the native field
+            var operation = CreateOperation(headers: receivedHeaders);
+            var outgoing = converter.ToNative(operation);
+
+            Assert.That(outgoing.MessageId, Is.EqualTo(originalId));
+        }
+
+        [Test]
         public void Sets_ReplyToQueueName_from_header()
         {
             var headers = new Dictionary<string, string>
@@ -269,6 +339,243 @@ public class IBMMQMessageConverterTests
             var mqMessage = converter.ToNative(operation);
 
             Assert.Throws<MQException>(() => mqMessage.GetStringProperty("nsbempty"));
+        }
+    }
+
+    [TestFixture]
+    public class NativePropertyLifting
+    {
+        [Test]
+        public void Lifts_CorrelationId_when_no_header_exists()
+        {
+            var correlationGuid = Guid.NewGuid();
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            var correlBytes = new byte[24];
+            Array.Copy(correlationGuid.ToByteArray(), correlBytes, 16);
+            mqMessage.CorrelationId = correlBytes;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.ContainKey(Headers.CorrelationId));
+            Assert.That(receivedHeaders[Headers.CorrelationId], Is.EqualTo(Convert.ToHexString(correlBytes)));
+        }
+
+        [Test]
+        public void Does_not_overwrite_existing_CorrelationId_header()
+        {
+            var headerCorrelationId = Guid.NewGuid().ToString();
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() },
+                { Headers.CorrelationId, headerCorrelationId }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            var differentCorrel = new byte[24];
+            Array.Copy(Guid.NewGuid().ToByteArray(), differentCorrel, 16);
+            mqMessage.CorrelationId = differentCorrel;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders[Headers.CorrelationId], Is.EqualTo(headerCorrelationId));
+        }
+
+        [Test]
+        public void Does_not_lift_CorrelationId_when_all_zeros()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.CorrelationId = new byte[24];
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.Not.ContainKey(Headers.CorrelationId));
+        }
+
+        [Test]
+        public void Lifts_ReplyToQueueName_when_no_header_exists()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.ReplyToQueueName = "REPLY.QUEUE";
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.ContainKey(Headers.ReplyToAddress));
+            Assert.That(receivedHeaders[Headers.ReplyToAddress], Is.EqualTo("REPLY.QUEUE"));
+        }
+
+        [Test]
+        public void Does_not_overwrite_existing_ReplyToAddress_header()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() },
+                { Headers.ReplyToAddress, "original.reply.queue" }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            // Set a different native ReplyToQueueName
+            mqMessage.ReplyToQueueName = "DIFFERENT.QUEUE";
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders[Headers.ReplyToAddress], Is.EqualTo("original.reply.queue"));
+        }
+
+        [Test]
+        public void Lifts_NonDurableMessage_when_persistence_is_non_persistent()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.Persistence = MQC.MQPER_NOT_PERSISTENT;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.ContainKey(Headers.NonDurableMessage));
+        }
+
+        [Test]
+        public void Does_not_lift_NonDurableMessage_when_persistent()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.Persistence = MQC.MQPER_PERSISTENT;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.Not.ContainKey(Headers.NonDurableMessage));
+        }
+
+        [Test]
+        public void Lifts_TimeToBeReceived_from_expiry()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.Expiry = 300; // 30 seconds in tenths
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.ContainKey(Headers.TimeToBeReceived));
+            Assert.That(receivedHeaders[Headers.TimeToBeReceived], Is.EqualTo(TimeSpan.FromSeconds(30).ToString()));
+        }
+
+        [Test]
+        public void Does_not_lift_TimeToBeReceived_when_unlimited()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.Expiry = MQC.MQEI_UNLIMITED;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.Not.ContainKey(Headers.TimeToBeReceived));
+        }
+
+        [Test]
+        public void Does_not_overwrite_existing_TimeToBeReceived_header()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() },
+                { Headers.TimeToBeReceived, TimeSpan.FromMinutes(5).ToString() }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            mqMessage.Expiry = 300; // different value
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders[Headers.TimeToBeReceived], Is.EqualTo(TimeSpan.FromMinutes(5).ToString()));
+        }
+
+        [Test]
+        public void Lifts_MessageId_from_native_when_no_header_exists()
+        {
+            // Create a raw MQMessage (no NServiceBus headers)
+            var mqMessage = new MQMessage();
+            var nativeId = new byte[24];
+            Array.Copy(Guid.NewGuid().ToByteArray(), nativeId, 16);
+            mqMessage.MessageId = nativeId;
+            mqMessage.Write(System.Text.Encoding.UTF8.GetBytes("test"));
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders, Does.ContainKey(Headers.MessageId));
+            Assert.That(receivedHeaders[Headers.MessageId], Is.EqualTo(Convert.ToHexString(nativeId)));
+            Assert.That(messageId, Is.EqualTo(Convert.ToHexString(nativeId)));
         }
     }
 }

--- a/src/Tests/MqMessageClearBehaviorTests.cs
+++ b/src/Tests/MqMessageClearBehaviorTests.cs
@@ -253,9 +253,11 @@ public class MqMessageClearBehaviorTests
         string id2 = string.Empty;
         converter.FromNative(recv2, headers2, ref id2);
 
-        Assert.That(headers2, Is.Empty,
-            "Raw message received after NServiceBus message must have zero headers. " +
-            "If headers leaked, the MQMessage was reused and PROPERTIES_IN_HANDLE " +
+        Assert.That(headers2, Does.Not.ContainKey(Headers.EnclosedMessageTypes),
+            "NServiceBus headers from the previous message must not leak onto the raw message. " +
+            "If they leaked, the MQMessage was reused and PROPERTIES_IN_HANDLE " +
             "carried stale properties from the previous receive.");
+        Assert.That(headers2, Does.Not.ContainKey(Headers.ContentType),
+            "NServiceBus headers from the previous message must not leak onto the raw message.");
     }
 }

--- a/src/Transport/IBMMQMessageConverter.cs
+++ b/src/Transport/IBMMQMessageConverter.cs
@@ -68,6 +68,11 @@ class IBMMQMessageConverter(MqPropertyNameEncoder propertyNameEncoder)
             }
         }
 
+        // Lift native MQ message properties to headers when no header value already exists.
+        // This enables interoperability with non-NServiceBus senders that set native MQ
+        // fields directly instead of encoding them as named string properties.
+        LiftNativeProperties(receivedMessage, messageHeaders);
+
         // Get message ID from NServiceBus headers, or fall back to native MQ message ID
         messageId = messageHeaders.TryGetValue(Headers.MessageId, out var msgId) && !string.IsNullOrEmpty(msgId)
             ? msgId
@@ -75,6 +80,40 @@ class IBMMQMessageConverter(MqPropertyNameEncoder propertyNameEncoder)
 
         return messageBody;
     }
+
+    static void LiftNativeProperties(MQMessage message, Dictionary<string, string> headers)
+    {
+        if (!headers.ContainsKey(Headers.MessageId) && !IsEmpty(message.MessageId))
+        {
+            headers[Headers.MessageId] = Convert.ToHexString(message.MessageId);
+        }
+
+        if (!headers.ContainsKey(Headers.CorrelationId) && !IsEmpty(message.CorrelationId))
+        {
+            headers[Headers.CorrelationId] = Convert.ToHexString(message.CorrelationId);
+        }
+
+        if (!headers.ContainsKey(Headers.ReplyToAddress))
+        {
+            var replyTo = message.ReplyToQueueName?.Trim();
+            if (!string.IsNullOrEmpty(replyTo))
+            {
+                headers[Headers.ReplyToAddress] = replyTo;
+            }
+        }
+
+        if (!headers.ContainsKey(Headers.NonDurableMessage) && message.Persistence == MQC.MQPER_NOT_PERSISTENT)
+        {
+            headers[Headers.NonDurableMessage] = true.ToString();
+        }
+
+        if (!headers.ContainsKey(Headers.TimeToBeReceived) && message.Expiry != MQC.MQEI_UNLIMITED)
+        {
+            headers[Headers.TimeToBeReceived] = TimeSpan.FromSeconds(message.Expiry / 10.0).ToString();
+        }
+    }
+
+    static bool IsEmpty(byte[]? bytes) => bytes is null || Array.TrueForAll(bytes, static b => b == 0);
 
     /// Always creates a new MQMessage — do not attempt to reuse MQMessage instances
     /// because ClearMessage does not fully reset all properties (see MqMessageClearBehaviorTests).
@@ -131,28 +170,52 @@ class IBMMQMessageConverter(MqPropertyNameEncoder propertyNameEncoder)
 
     static void SetCorrelationId(OutgoingMessage outgoingMessage, MQMessage message)
     {
-        if (outgoingMessage.Headers.TryGetValue(Headers.CorrelationId, out var correlationId))
+        if (outgoingMessage.Headers.TryGetValue(Headers.CorrelationId, out var correlationId)
+            && TryConvertToMqId(correlationId, out var correlBytes))
         {
-            if (Guid.TryParse(correlationId, out var correlationGuid))
-            {
-                var correlBytes = new byte[24];
-                Array.Copy(correlationGuid.ToByteArray(), correlBytes, 16);
-                message.CorrelationId = correlBytes;
-            }
+            message.CorrelationId = correlBytes;
         }
     }
 
     static void SetMessageId(OutgoingMessage outgoingMessage, MQMessage message)
     {
-        if (outgoingMessage.Headers.TryGetValue(Headers.MessageId, out var messageId))
+        if (outgoingMessage.Headers.TryGetValue(Headers.MessageId, out var messageId)
+            && TryConvertToMqId(messageId, out var idBytes))
         {
-            if (Guid.TryParse(messageId, out var messageGuid))
+            message.MessageId = idBytes;
+        }
+    }
+
+    static bool TryConvertToMqId(string? value, out byte[] mqId)
+    {
+        mqId = new byte[24];
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        if (Guid.TryParse(value, out var guid))
+        {
+            Array.Copy(guid.ToByteArray(), mqId, 16);
+            return true;
+        }
+
+        try
+        {
+            var bytes = Convert.FromHexString(value);
+            if (bytes.Length <= 24)
             {
-                var messageIdByes = new byte[24];
-                Array.Copy(messageGuid.ToByteArray(), messageIdByes, 16);
-                message.MessageId = messageIdByes;
+                Array.Copy(bytes, mqId, bytes.Length);
+                return true;
             }
         }
+        catch (FormatException)
+        {
+            // Not a valid hex string
+        }
+
+        return false;
     }
 
     static void SetReplyToQueueName(OutgoingMessage outgoingMessage, MQMessage message)


### PR DESCRIPTION
This improves interop and allows NServiceBus to reply to a native message, setting the correct native message property so any IBM MQ client that specifically queries for a specific message correlation ID will be able to get that message.

## Summary

- Promotes native IBM MQ message properties to NServiceBus headers in `FromNative` when no header value already exists, enabling interop with non-NServiceBus senders
- Lifted properties: `MessageId`, `CorrelationId`, `ReplyToQueueName` → `ReplyToAddress`, `Persistence` → `NonDurableMessage`, `Expiry` → `TimeToBeReceived`
- Existing NServiceBus header values always take precedence over native properties