### PR TITLE
Add OpenTelemetry tracing via DiagnosticSource

### DIFF
--- a/src/Tests/ActivitySourceTests.cs
+++ b/src/Tests/ActivitySourceTests.cs
@@ -1,0 +1,66 @@
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using NUnit.Framework;
+
+[TestFixture]
+public class ActivitySourceTests
+{
+    [Test]
+    public void Has_expected_name()
+    {
+        Assert.That(ActivitySources.Main.Name, Is.EqualTo("NServiceBus.Transport.IBMMQ"));
+    }
+
+    [Test]
+    public void Has_version()
+    {
+        Assert.That(ActivitySources.Main.Version, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void Version_does_not_contain_build_metadata()
+    {
+        Assert.That(ActivitySources.Main.Version, Does.Not.Contain("+"));
+    }
+
+    [Test]
+    public void Name_constant_matches_activity_source()
+    {
+        Assert.That(ActivitySources.Main.Name, Is.EqualTo(ActivitySources.Name));
+    }
+
+    [Test]
+    [TestCase(ActivitySources.Receive)]
+    [TestCase(ActivitySources.Dispatch)]
+    [TestCase(ActivitySources.PutToQueue)]
+    [TestCase(ActivitySources.PutToTopic)]
+    [TestCase(ActivitySources.Attempt)]
+    public void Activity_names_are_prefixed_with_source_name(string activityName)
+    {
+        Assert.That(activityName, Does.StartWith(ActivitySources.Name));
+    }
+
+    [Test]
+    public void Listener_receives_activities()
+    {
+        var stoppedActivities = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivitySources.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => stoppedActivities.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using (ActivitySources.Main.StartActivity(ActivitySources.Dispatch, ActivityKind.Internal))
+        {
+        }
+
+        Assert.That(stoppedActivities, Has.Count.EqualTo(1));
+        Assert.That(stoppedActivities[0].OperationName, Is.EqualTo(ActivitySources.Dispatch));
+        Assert.That(stoppedActivities[0].Kind, Is.EqualTo(ActivityKind.Internal));
+    }
+}

--- a/src/Transport/Diagnostics/ActivitySources.cs
+++ b/src/Transport/Diagnostics/ActivitySources.cs
@@ -1,0 +1,49 @@
+namespace NServiceBus.Transport.IBMMQ;
+
+using System.Diagnostics;
+using System.Reflection;
+
+static class ActivitySources
+{
+    public const string Name = "NServiceBus.Transport.IBMMQ";
+
+    // Activity names
+    public const string Receive = "NServiceBus.Transport.IBMMQ.Receive";
+    public const string Dispatch = "NServiceBus.Transport.IBMMQ.Dispatch";
+    public const string PutToQueue = "NServiceBus.Transport.IBMMQ.PutToQueue";
+    public const string PutToTopic = "NServiceBus.Transport.IBMMQ.PutToTopic";
+    public const string Attempt = "NServiceBus.Transport.IBMMQ.Attempt";
+
+    // OTel messaging semantic convention tags
+    public const string TagMessagingSystem = "messaging.system";
+    public const string TagMessagingSystemValue = "ibm_mq";
+    public const string TagDestinationName = "messaging.destination.name";
+    public const string TagOperationType = "messaging.operation.type";
+    public const string TagMessageId = "messaging.message.id";
+    public const string TagBatchMessageCount = "messaging.batch.message_count";
+
+    // OTel messaging operation types
+    public const string OperationSend = "send";
+    public const string OperationPublish = "publish";
+    public const string OperationReceive = "receive";
+
+    // Vendor-specific tags
+    public const string TagTopicString = "nservicebus.transport.ibmmq.topic_string";
+    public const string TagFailureCount = "nservicebus.transport.ibmmq.failure_count";
+
+    // Activity event names
+    public const string CommitEvent = "mq.commit";
+    public const string BackoutEvent = "mq.backout";
+
+    static readonly string Version = GetVersion();
+
+    static string GetVersion()
+    {
+        var informationalVersion = typeof(ActivitySources).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
+        var plusIndex = informationalVersion.IndexOf('+');
+        return plusIndex >= 0 ? informationalVersion[..plusIndex] : informationalVersion;
+    }
+
+    public static readonly ActivitySource Main = new(Name, Version);
+}

--- a/src/Transport/MqConnection.cs
+++ b/src/Transport/MqConnection.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.IBMMQ;
 
+using System.Diagnostics;
 using IBM.WMQ;
 using Logging;
 
@@ -17,13 +18,27 @@ sealed class MqConnection(
 
     public void PutToQueue(string destination, MQMessage message, MQPutMessageOptions options)
     {
+        using var activity = ActivitySources.Main.StartActivity(ActivitySources.PutToQueue, ActivityKind.Producer);
+        if (activity is { IsAllDataRequested: true })
+        {
+            activity.DisplayName = $"send {destination}";
+            activity.SetTag(ActivitySources.TagMessagingSystem, ActivitySources.TagMessagingSystemValue);
+            activity.SetTag(ActivitySources.TagDestinationName, destination);
+            activity.SetTag(ActivitySources.TagOperationType, ActivitySources.OperationSend);
+        }
+
         var queue = queueCache.GetOrAdd(destination, OpenSendQueue);
         try
         {
             queue.Put(message, options);
+            if (activity is { IsAllDataRequested: true } && message.MessageId is { Length: > 0 })
+            {
+                activity.SetTag(ActivitySources.TagMessageId, Convert.ToHexString(message.MessageId));
+            }
         }
-        catch (MQException)
+        catch (MQException ex)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             queueCache.Evict(destination);
             throw;
         }
@@ -31,13 +46,28 @@ sealed class MqConnection(
 
     public void PutToTopic(string topicName, string topicString, MQMessage message, MQPutMessageOptions options)
     {
+        using var activity = ActivitySources.Main.StartActivity(ActivitySources.PutToTopic, ActivityKind.Producer);
+        if (activity is { IsAllDataRequested: true })
+        {
+            activity.DisplayName = $"publish {topicName}";
+            activity.SetTag(ActivitySources.TagMessagingSystem, ActivitySources.TagMessagingSystemValue);
+            activity.SetTag(ActivitySources.TagDestinationName, topicName);
+            activity.SetTag(ActivitySources.TagTopicString, topicString);
+            activity.SetTag(ActivitySources.TagOperationType, ActivitySources.OperationPublish);
+        }
+
         var topic = topicCache.GetOrAdd(topicName, _ => EnsureTopic(topicName, topicString));
         try
         {
             topic.Put(message, options);
+            if (activity is { IsAllDataRequested: true } && message.MessageId is { Length: > 0 })
+            {
+                activity.SetTag(ActivitySources.TagMessageId, Convert.ToHexString(message.MessageId));
+            }
         }
-        catch (MQException)
+        catch (MQException ex)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             topicCache.Evict(topicName);
             throw;
         }
@@ -76,8 +106,17 @@ sealed class MqConnection(
     public MQQueue OpenInputQueue(string name) =>
         queueManager.AccessQueue(name, MQC.MQOO_INPUT_AS_Q_DEF);
 
-    public void Commit() => queueManager.Commit();
-    public void Backout() => queueManager.Backout();
+    public void Commit()
+    {
+        queueManager.Commit();
+        Activity.Current?.AddEvent(new ActivityEvent(ActivitySources.CommitEvent));
+    }
+
+    public void Backout()
+    {
+        queueManager.Backout();
+        Activity.Current?.AddEvent(new ActivityEvent(ActivitySources.BackoutEvent));
+    }
 
     public void Disconnect()
     {

--- a/src/Transport/Receiving/ReceiveStrategy.cs
+++ b/src/Transport/Receiving/ReceiveStrategy.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.IBMMQ;
 
+using System.Diagnostics;
 using IBM.WMQ;
 using Logging;
 
@@ -61,6 +62,22 @@ abstract class ReceiveStrategy(MqConnection connection, IBMMQMessageConverter me
         Dictionary<string, string> messageHeaders = [];
         var messageBody = messageConverter.FromNative(receivedMessage, messageHeaders, ref messageId);
 
+        // Start transport-level activity after a message is dequeued. NServiceBus core
+        // parents its ReceiveMessage activity to this transport activity when it finds
+        // it in the MessageContext extensions (set in ProcessMessage below).
+        using var activity = ActivitySources.Main.StartActivity(ActivitySources.Receive, ActivityKind.Consumer);
+        if (activity != null)
+        {
+            activity.DisplayName = $"receive {context.QueueName}";
+            if (activity.IsAllDataRequested)
+            {
+                activity.SetTag(ActivitySources.TagMessagingSystem, ActivitySources.TagMessagingSystemValue);
+                activity.SetTag(ActivitySources.TagDestinationName, context.QueueName);
+                activity.SetTag(ActivitySources.TagOperationType, ActivitySources.OperationReceive);
+                activity.SetTag(ActivitySources.TagMessageId, messageId);
+            }
+        }
+
         if (log.IsDebugEnabled)
         {
             log.DebugFormat("Worker {0} received message {1}", context.WorkerIndex, messageId);
@@ -80,8 +97,17 @@ abstract class ReceiveStrategy(MqConnection connection, IBMMQMessageConverter me
 
     protected ValueTask ProcessMessage(
         ReceivedMessage msg, TransportTransaction tx,
-        Extensibility.ContextBag ctx, CancellationToken cancellationToken = default) =>
-        new(context.OnMessage(CreateMessageContext(msg, tx, ctx), cancellationToken));
+        Extensibility.ContextBag ctx, CancellationToken cancellationToken = default)
+    {
+        // Set the current transport activity so NServiceBus core can parent its
+        // receive pipeline activity to this transport activity.
+        if (Activity.Current is { } transportActivity)
+        {
+            ctx.Set(transportActivity);
+        }
+
+        return new(context.OnMessage(CreateMessageContext(msg, tx, ctx), cancellationToken));
+    }
 
     protected ValueTask<ErrorHandleResult> ProcessError(
         ReceivedMessage msg, TransportTransaction tx, Exception ex,
@@ -108,6 +134,21 @@ abstract class ReceiveStrategy(MqConnection connection, IBMMQMessageConverter me
                 onErrorEx, cancellationToken);
             return ErrorHandleResult.RetryRequired;
         }
+    }
+
+    /// <summary>
+    /// Records error status and failure count on the current transport activity.
+    /// Called from receive strategies when message processing fails.
+    /// </summary>
+    protected static void RecordError(Exception ex, int failureCount)
+    {
+        if (Activity.Current is not { } activity)
+        {
+            return;
+        }
+
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity.SetTag(ActivitySources.TagFailureCount, failureCount);
     }
 
     MessageContext CreateMessageContext(

--- a/src/Transport/Receiving/Strategies/AtomicReceiveStrategy.cs
+++ b/src/Transport/Receiving/Strategies/AtomicReceiveStrategy.cs
@@ -62,6 +62,7 @@ sealed class AtomicReceiveStrategy(
 
                 if (errorResult == ErrorHandleResult.Handled)
                 {
+                    RecordError(failureRecord.Exception, failureRecord.NumberOfProcessingAttempts);
                     Connection.Commit();
                     failureInfoStorage.ClearFailure(msg.Id);
                     return;
@@ -87,6 +88,7 @@ sealed class AtomicReceiveStrategy(
         }
         catch (Exception ex)
         {
+            RecordError(ex, (failureRecord?.NumberOfProcessingAttempts ?? 0) + 1);
             failureInfoStorage.RecordFailure(msg.Id, ex, contextBag);
             Connection.Backout();
         }

--- a/src/Transport/Receiving/Strategies/RetryLoopReceiveStrategy.cs
+++ b/src/Transport/Receiving/Strategies/RetryLoopReceiveStrategy.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.IBMMQ;
 
+using System.Diagnostics;
 using Logging;
 
 abstract class RetryLoopReceiveStrategy(
@@ -23,6 +24,7 @@ abstract class RetryLoopReceiveStrategy(
         while (true)
         {
             var contextBag = new Extensibility.ContextBag();
+            using var attemptActivity = ActivitySources.Main.StartActivity(ActivitySources.Attempt, ActivityKind.Internal);
 
             try
             {
@@ -44,6 +46,8 @@ abstract class RetryLoopReceiveStrategy(
             catch (Exception ex)
             {
                 failureCount++;
+                attemptActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                attemptActivity?.SetTag(ActivitySources.TagFailureCount, failureCount);
 
                 var result = await InvokeOnError(
                     msg,
@@ -56,6 +60,7 @@ abstract class RetryLoopReceiveStrategy(
 
                 if (result is ErrorHandleResult.Handled)
                 {
+                    RecordError(ex, failureCount);
                     OnErrorHandled();
                     return;
                 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.IBMMQ;
 
+using System.Diagnostics;
 using IBM.WMQ;
 
 sealed class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology, IBMMQMessageConverter messageConverter)
@@ -8,42 +9,59 @@ sealed class MessageDispatcher(MqConnectionPool sendPool, TopicTopology topology
     public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction,
         CancellationToken cancellationToken = default)
     {
-        if (transaction.TryGet<MqConnection>(out var receiveConn))
+        using var activity = ActivitySources.Main.StartActivity(ActivitySources.Dispatch, ActivityKind.Internal);
+        if (activity is { IsAllDataRequested: true })
         {
-            // Sends atomic with receive: dispatch uses the receive connection's SYNCPOINT.
-            // Connection-level errors are not handled here — the message pump's reconnect
-            // loop owns the lifecycle of this connection and will restart on failure.
-            SendAll(receiveConn, outgoingMessages, atomic: true);
+            activity.DisplayName = "dispatch";
+            activity.SetTag(ActivitySources.TagMessagingSystem, ActivitySources.TagMessagingSystemValue);
+            activity.SetTag(ActivitySources.TagBatchMessageCount,
+                outgoingMessages.UnicastTransportOperations.Count + outgoingMessages.MulticastTransportOperations.Count);
         }
-        else
+
+        try
         {
-            var conn = sendPool.Rent(cancellationToken);
-            try
+            if (transaction.TryGet<MqConnection>(out var receiveConn))
             {
-                SendAll(conn, outgoingMessages, atomic: false);
-                sendPool.Return(conn);
-                conn = null;
+                // Sends atomic with receive: dispatch uses the receive connection's SYNCPOINT.
+                // Connection-level errors are not handled here — the message pump's reconnect
+                // loop owns the lifecycle of this connection and will restart on failure.
+                SendAll(receiveConn, outgoingMessages, atomic: true);
             }
-            catch (MQException ex) when (IsConnectionLevelError(ex))
+            else
             {
-                // MQException with a connection-level reason code means the connection
-                // is dirty/broken — discard it rather than returning it to the pool.
-                if (conn != null)
+                var conn = sendPool.Rent(cancellationToken);
+                try
                 {
-                    sendPool.Discard(conn);
-                }
-
-                throw;
-            }
-            catch
-            {
-                if (conn != null)
-                {
+                    SendAll(conn, outgoingMessages, atomic: false);
                     sendPool.Return(conn);
+                    conn = null;
                 }
+                catch (MQException ex) when (IsConnectionLevelError(ex))
+                {
+                    // MQException with a connection-level reason code means the connection
+                    // is dirty/broken — discard it rather than returning it to the pool.
+                    if (conn != null)
+                    {
+                        sendPool.Discard(conn);
+                    }
 
-                throw;
+                    throw;
+                }
+                catch
+                {
+                    if (conn != null)
+                    {
+                        sendPool.Return(conn);
+                    }
+
+                    throw;
+                }
             }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
## Summary

- Adds transport-level `ActivitySource` (`NServiceBus.Transport.IBMMQ`) with version derived from `AssemblyInformationalVersionAttribute` at runtime
- **Receive path**: starts a `Consumer` activity after `queue.Get()` succeeds and sets it on the `ContextBag` so NServiceBus core parents its `ReceiveMessage` activity to it
- **Send path**: starts a `Producer` activity wrapping `Dispatch()`, automatically a child of core's send/publish activity
- **Per-destination**: `PutToQueue` and `PutToTopic` each get their own child activity with destination-specific tags and display names
- **Commit/backout**: recorded as `mq.commit` / `mq.backout` activity events on the current span
- Tags follow [OTel messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/): `messaging.system`, `messaging.destination.name`, `messaging.operation.type`, `messaging.message.id`

### Resulting trace hierarchy

```
Transport: receive MY.QUEUE (Consumer)
  ├── event: mq.commit | mq.backout
  └── Core: ReceiveMessage (Consumer)
       └── Core: InvokeHandler (Internal)
            └── Core: SendMessage (Producer)
                 └── Transport: dispatch (Producer)
                      ├── Transport: send TARGET.QUEUE (Producer)
                      └── Transport: publish DEV.MY.EVENT (Producer)
```

### Key integration point

NServiceBus core's `ActivityFactory.StartIncomingPipelineActivity()` already checks `context.Extensions.TryGet<Activity>()` for a transport-provided activity. When found, core creates its receive activity as a **child** of the transport activity and adds a **link** to the sender's traceparent. This transport sets that activity via `ContextBag.Set()` in `ProcessMessage()`.