### PR TITLE
Publish CLI tool package via release pipeline

### DIFF
--- a/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="IBMMQDotnetClient" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+    <PackageReference Include="Particular.Packaging" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Add `Particular.Packaging` reference to the CommandLine project so the nupkg is generated in `nugets/` and picked up by CI/release alongside the transport package
- The CLI tool (`ibmmq-transport`) was already configured as a .NET global tool (`PackAsTool`) but its package was never output to `nugets/`, so it was excluded from the release pipeline

## Test plan

- [x] Verify `nugets/` contains both `NServiceBus.Transport.IBMMQ.*.nupkg` and `NServiceBus.Transport.IBMMQ.CommandLine.*.nupkg` after build
- [x] CI passes