### PR TITLE
Add --assembly option for polymorphic subscribe/unsubscribe

### DIFF
--- a/src/CommandLine/EndpointCommand.cs
+++ b/src/CommandLine/EndpointCommand.cs
@@ -46,18 +46,24 @@ static class EndpointCommand
             var name = cmd.Argument("name", "Name of the endpoint").IsRequired();
             var eventType = cmd.Argument("event-type", "Fully qualified .NET type name of the event").IsRequired();
             var topicPrefix = cmd.Option("--topic-prefix", "Topic name prefix (default: DEV)", CommandOptionType.SingleValue);
+            var assemblyPath = cmd.Option("--assembly", "Path to assembly containing the event type (enables polymorphic subscriptions)", CommandOptionType.SingleValue);
 
             cmd.OnExecute(() =>
             {
                 using var connection = connectionOptions.Connect();
 
                 var prefix = topicPrefix.Value() ?? "DEV";
-                var topicName = TopicNaming.GenerateTopicName(eventType.Value!, prefix);
-                var topicString = TopicNaming.GenerateTopicString(eventType.Value!, prefix);
-                var subscriptionName = TopicNaming.GenerateSubscriptionName(name.Value!, topicString);
+                var typeNames = ResolveEventTypeNames(eventType.Value!, assemblyPath.Value());
 
-                Topic.Create(connection, topicName, topicString);
-                Subscription.Create(connection, topicString, subscriptionName, name.Value!);
+                foreach (var typeName in typeNames)
+                {
+                    var topicName = TopicNaming.GenerateTopicName(typeName, prefix);
+                    var topicString = TopicNaming.GenerateTopicString(typeName, prefix);
+                    var subscriptionName = TopicNaming.GenerateSubscriptionName(name.Value!, topicString);
+
+                    Topic.Create(connection, topicName, topicString);
+                    Subscription.Create(connection, topicString, subscriptionName, name.Value!);
+                }
             });
         });
     }
@@ -72,17 +78,33 @@ static class EndpointCommand
             var name = cmd.Argument("name", "Name of the endpoint").IsRequired();
             var eventType = cmd.Argument("event-type", "Fully qualified .NET type name of the event").IsRequired();
             var topicPrefix = cmd.Option("--topic-prefix", "Topic name prefix (default: DEV)", CommandOptionType.SingleValue);
+            var assemblyPath = cmd.Option("--assembly", "Path to assembly containing the event type (enables polymorphic unsubscriptions)", CommandOptionType.SingleValue);
 
             cmd.OnExecute(() =>
             {
                 using var connection = connectionOptions.Connect();
 
                 var prefix = topicPrefix.Value() ?? "DEV";
-                var topicString = TopicNaming.GenerateTopicString(eventType.Value!, prefix);
-                var subscriptionName = TopicNaming.GenerateSubscriptionName(name.Value!, topicString);
+                var typeNames = ResolveEventTypeNames(eventType.Value!, assemblyPath.Value());
 
-                Subscription.Delete(connection, subscriptionName);
+                foreach (var typeName in typeNames)
+                {
+                    var topicString = TopicNaming.GenerateTopicString(typeName, prefix);
+                    var subscriptionName = TopicNaming.GenerateSubscriptionName(name.Value!, topicString);
+
+                    Subscription.Delete(connection, subscriptionName);
+                }
             });
         });
+    }
+
+    static IReadOnlyList<string> ResolveEventTypeNames(string eventTypeName, string? assemblyPath)
+    {
+        if (assemblyPath is null)
+        {
+            return [eventTypeName];
+        }
+
+        return EventTypeResolver.Resolve(eventTypeName, assemblyPath);
     }
 }

--- a/src/CommandLine/EventTypeResolver.cs
+++ b/src/CommandLine/EventTypeResolver.cs
@@ -1,0 +1,76 @@
+namespace NServiceBus.Transport.IBMMQ.CommandLine;
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+static class EventTypeResolver
+{
+    public static IReadOnlyList<string> Resolve(string eventTypeName, string assemblyPath)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
+        var runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
+        var localAssemblies = Directory.GetFiles(directory, "*.dll");
+
+        var resolver = new PathAssemblyResolver(runtimeAssemblies.Concat(localAssemblies));
+        using var mlc = new MetadataLoadContext(resolver);
+
+        var assembly = mlc.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
+
+        var eventType = assembly.GetType(eventTypeName)
+            ?? throw new InvalidOperationException(
+                $"Type '{eventTypeName}' not found in assembly '{Path.GetFileName(assemblyPath)}'.");
+
+        var targetFullName = eventType.FullName!;
+        var names = new List<string> { targetFullName };
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type.FullName != targetFullName && IsAssignableTo(type, targetFullName))
+            {
+                names.Add(type.FullName!);
+            }
+        }
+
+        return names;
+    }
+
+    static bool IsAssignableTo(Type type, string targetFullName)
+    {
+        // Walk the base class chain
+        try
+        {
+            var current = type.BaseType;
+            while (current is not null)
+            {
+                if (current.FullName == targetFullName)
+                {
+                    return true;
+                }
+
+                current = current.BaseType;
+            }
+        }
+        catch (FileNotFoundException)
+        {
+            // Referenced assembly not available in MetadataLoadContext — skip base chain
+        }
+
+        // Check interfaces
+        try
+        {
+            foreach (var iface in type.GetInterfaces())
+            {
+                if (iface.FullName == targetFullName)
+                {
+                    return true;
+                }
+            }
+        }
+        catch (FileNotFoundException)
+        {
+            // Referenced assembly not available in MetadataLoadContext — skip interfaces
+        }
+
+        return false;
+    }
+}

--- a/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.IBMMQ.CommandLine.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="IBMMQDotnetClient" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Particular.Packaging" PrivateAssets="All" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 
 </Project>

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -134,6 +134,22 @@ public class CommandLineTests
         Assert.That(output, Does.Contain("--topic-prefix"));
     }
 
+    [Test]
+    public async Task Endpoint_subscribe_help_shows_assembly_option()
+    {
+        var (output, _, _) = await Execute("endpoint subscribe --help").ConfigureAwait(false);
+
+        Assert.That(output, Does.Contain("--assembly"));
+    }
+
+    [Test]
+    public async Task Endpoint_unsubscribe_help_shows_assembly_option()
+    {
+        var (output, _, _) = await Execute("endpoint unsubscribe --help").ConfigureAwait(false);
+
+        Assert.That(output, Does.Contain("--assembly"));
+    }
+
 #pragma warning disable PS0018
     static async Task<(string output, string error, int exitCode)> Execute(string command)
 #pragma warning restore PS0018

--- a/src/CommandLineTests/EventTypeResolverTests.cs
+++ b/src/CommandLineTests/EventTypeResolverTests.cs
@@ -1,0 +1,60 @@
+namespace NServiceBus.Transport.IBMMQ.CommandLine.Tests;
+
+using System.Reflection;
+using NUnit.Framework;
+
+[TestFixture]
+public class EventTypeResolverTests
+{
+    static readonly string AssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    [Test]
+    public void Resolve_finds_type_in_assembly()
+    {
+        var names = EventTypeResolver.Resolve("NServiceBus.Transport.IBMMQ.CommandLine.Tests.BaseEvent", AssemblyPath);
+
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.BaseEvent"));
+    }
+
+    [Test]
+    public void Resolve_throws_for_unknown_type()
+    {
+        Assert.That(
+            () => EventTypeResolver.Resolve("DoesNot.Exist", AssemblyPath),
+            Throws.InvalidOperationException.With.Message.Contains("not found"));
+    }
+
+    [Test]
+    public void Resolve_returns_only_leaf_type_when_no_derived_types()
+    {
+        var names = EventTypeResolver.Resolve("NServiceBus.Transport.IBMMQ.CommandLine.Tests.LeafEvent", AssemblyPath);
+
+        Assert.That(names, Is.EqualTo(new[] { "NServiceBus.Transport.IBMMQ.CommandLine.Tests.LeafEvent" }));
+    }
+
+    [Test]
+    public void Resolve_includes_derived_types()
+    {
+        var names = EventTypeResolver.Resolve("NServiceBus.Transport.IBMMQ.CommandLine.Tests.BaseEvent", AssemblyPath);
+
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.BaseEvent"));
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.DerivedEvent"));
+    }
+
+    [Test]
+    public void Resolve_includes_interface_implementors()
+    {
+        var names = EventTypeResolver.Resolve("NServiceBus.Transport.IBMMQ.CommandLine.Tests.ITestEvent", AssemblyPath);
+
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.ITestEvent"));
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.BaseEvent"));
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.DerivedEvent"));
+        Assert.That(names, Does.Contain("NServiceBus.Transport.IBMMQ.CommandLine.Tests.LeafEvent"));
+    }
+}
+
+// Test type hierarchy
+public interface ITestEvent;
+public class BaseEvent : ITestEvent;
+public class DerivedEvent : BaseEvent;
+public class LeafEvent : ITestEvent;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.5" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Add optional `--assembly` flag to `endpoint subscribe` and `endpoint unsubscribe` commands
- When provided, loads the assembly via `MetadataLoadContext` (no runtime dependency resolution needed), validates the event type exists, and discovers all derived/implementing types
- Creates topics and subscriptions for the full type hierarchy, matching the runtime transport's polymorphic pub/sub behavior in `TopicPerEventTopology`
- Without `--assembly`, behavior is unchanged (single string-based subscription)

### Example

```bash
# Subscribes to Acme.OrderPlaced AND Acme.ExpressOrderPlaced (which inherits OrderPlaced)
ibmmq-transport --queue-manager QM1 endpoint subscribe Acme.Billing Acme.OrderPlaced --assembly path/to/Acme.Shared.dll
```

## Test plan

- [x] `EventTypeResolverTests` — type resolution, missing type error, leaf types, inheritance, interface implementors
- [x] `CommandLineTests` — `--assembly` appears in subscribe/unsubscribe help output
- [x] CI passes
- [x] Manual: run against IBM MQ container, verify polymorphic subscriptions created