### PR TITLE
Add tests for edge cases and untested types

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,15 +1,14 @@
 <Project>
-
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.2" />
     <PackageVersion Include="IBMMQDotnetClient" Version="9.4.5" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NServiceBus" Version="10.1.0" />
     <PackageVersion Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.0" />
@@ -26,5 +25,4 @@
     <PackageVersion Include="System.IO.Hashing" Version="10.0.5" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
   </ItemGroup>
-
 </Project>

--- a/src/Tests/DestinationCacheTests.cs
+++ b/src/Tests/DestinationCacheTests.cs
@@ -1,0 +1,140 @@
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using System;
+using IBM.WMQ;
+using NUnit.Framework;
+
+[TestFixture]
+[Category("RequiresBroker")]
+public class DestinationCacheTests
+{
+    const string QueueName = "SYSTEM.DEFAULT.LOCAL.QUEUE";
+
+    [OneTimeSetUp]
+    public void Setup() => BrokerRequirement.Verify();
+
+    [Test]
+    public void GetOrAdd_returns_same_handle_for_same_key()
+    {
+        using var qm = TestBrokerConnection.Connect();
+        using var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 10);
+
+        var handle1 = cache.GetOrAdd(QueueName, _ => qm.AccessQueue(QueueName, MQC.MQOO_INQUIRE));
+        var handle2 = cache.GetOrAdd(QueueName, _ => qm.AccessQueue(QueueName, MQC.MQOO_INQUIRE));
+
+        Assert.That(handle2, Is.SameAs(handle1));
+    }
+
+    [Test]
+    public void GetOrAdd_evicts_lru_when_capacity_exceeded()
+    {
+        using var qm = TestBrokerConnection.Connect();
+        var openCount = 0;
+        using var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 2);
+
+        MQQueue Open(string _)
+        {
+            openCount++;
+            return qm.AccessQueue(QueueName, MQC.MQOO_INQUIRE);
+        }
+
+        cache.GetOrAdd("a", Open);
+        cache.GetOrAdd("b", Open);
+        cache.GetOrAdd("c", Open); // evicts "a"
+
+        Assert.That(openCount, Is.EqualTo(3));
+
+        // "a" was evicted — factory should be called again
+        cache.GetOrAdd("a", Open);
+        Assert.That(openCount, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void GetOrAdd_promotes_recently_accessed_entry()
+    {
+        using var qm = TestBrokerConnection.Connect();
+        var openCount = 0;
+        using var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 2);
+
+        MQQueue Open(string _)
+        {
+            openCount++;
+            return qm.AccessQueue(QueueName, MQC.MQOO_INQUIRE);
+        }
+
+        cache.GetOrAdd("a", Open); // [a]
+        cache.GetOrAdd("b", Open); // [b, a]
+        cache.GetOrAdd("a", Open); // promotes a → [a, b]
+        cache.GetOrAdd("c", Open); // evicts "b" (LRU) → [c, a]
+
+        // "a" should still be cached
+        cache.GetOrAdd("a", Open);
+        Assert.That(openCount, Is.EqualTo(3)); // a, b, c — no re-open of a
+
+        // "b" was evicted
+        cache.GetOrAdd("b", Open);
+        Assert.That(openCount, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Evict_removes_entry()
+    {
+        using var qm = TestBrokerConnection.Connect();
+        var openCount = 0;
+        using var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 10);
+
+        MQQueue Open(string _)
+        {
+            openCount++;
+            return qm.AccessQueue(QueueName, MQC.MQOO_INQUIRE);
+        }
+
+        cache.GetOrAdd("a", Open);
+        cache.Evict("a");
+
+        cache.GetOrAdd("a", Open);
+        Assert.That(openCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Evict_is_idempotent_for_unknown_key()
+    {
+        using var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 10);
+
+        Assert.DoesNotThrow(() => cache.Evict("nonexistent"));
+    }
+
+    [Test]
+    public void Dispose_is_idempotent()
+    {
+        var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 10);
+
+        cache.Dispose();
+        Assert.DoesNotThrow(() => cache.Dispose());
+    }
+
+    [Test]
+    public void GetOrAdd_throws_after_dispose()
+    {
+        var cache = new DestinationCache<MQQueue>(
+            NServiceBus.Logging.LogManager.GetLogger<DestinationCacheTests>(),
+            capacity: 10);
+
+        cache.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+            cache.GetOrAdd("a", _ => throw new InvalidOperationException("should not be called")));
+    }
+}

--- a/src/Tests/IBMMQMessageConverterTests.cs
+++ b/src/Tests/IBMMQMessageConverterTests.cs
@@ -344,6 +344,97 @@ public class IBMMQMessageConverterTests
     }
 
     [TestFixture]
+    public class RoundTrip
+    {
+        [Test]
+        public void Headers_survive_ToNative_then_FromNative()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() },
+                { "NServiceBus.EnclosedMessageTypes", "MyApp.Events.OrderPlaced" },
+                { "custom-header", "custom-value" }
+            };
+            var body = System.Text.Encoding.UTF8.GetBytes("payload");
+            var operation = CreateOperation(headers: headers, body: body);
+
+            var mqMessage = converter.ToNative(operation);
+            mqMessage.Seek(0);
+
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            var receivedBody = converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders["NServiceBus.EnclosedMessageTypes"], Is.EqualTo("MyApp.Events.OrderPlaced"));
+            Assert.That(receivedHeaders["custom-header"], Is.EqualTo("custom-value"));
+            Assert.That(receivedBody, Is.EqualTo(body));
+        }
+
+        [Test]
+        public void Empty_header_values_survive_round_trip()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() },
+                { "EmptyHeader", "" },
+                { "NormalHeader", "value" }
+            };
+            var operation = CreateOperation(headers: headers);
+
+            var mqMessage = converter.ToNative(operation);
+            mqMessage.Seek(0);
+
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedHeaders["EmptyHeader"], Is.EqualTo(""));
+            Assert.That(receivedHeaders["NormalHeader"], Is.EqualTo("value"));
+        }
+
+        [Test]
+        public void Empty_body_survives_round_trip()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, Guid.NewGuid().ToString() }
+            };
+            var operation = CreateOperation(headers: headers, body: []);
+
+            var mqMessage = converter.ToNative(operation);
+            mqMessage.Seek(0);
+
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            var receivedBody = converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(receivedBody, Is.Empty);
+        }
+
+        [Test]
+        public void MessageId_falls_back_to_native_when_header_is_empty()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, "" }
+            };
+            var operation = CreateOperation(headers: headers);
+            var mqMessage = converter.ToNative(operation);
+
+            var nativeId = new byte[24];
+            Array.Copy(Guid.NewGuid().ToByteArray(), nativeId, 16);
+            mqMessage.MessageId = nativeId;
+
+            mqMessage.Seek(0);
+            var receivedHeaders = new Dictionary<string, string>();
+            string messageId = string.Empty;
+            converter.FromNative(mqMessage, receivedHeaders, ref messageId);
+
+            Assert.That(messageId, Is.EqualTo(Convert.ToHexString(nativeId)));
+        }
+    }
+
+    [TestFixture]
     public class NativePropertyLifting
     {
         [Test]

--- a/src/Tests/InMemoryFailureInfoStorageTests.cs
+++ b/src/Tests/InMemoryFailureInfoStorageTests.cs
@@ -1,0 +1,141 @@
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using System;
+using Microsoft.Extensions.Time.Testing;
+using NServiceBus.Extensibility;
+using NUnit.Framework;
+
+[TestFixture]
+public class InMemoryFailureInfoStorageTests
+{
+    [Test]
+    public void RecordFailure_stores_entry()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        storage.RecordFailure("msg-1", new Exception("fail"), new ContextBag());
+
+        Assert.That(storage.TryGetFailureInfo("msg-1", out var info), Is.True);
+        Assert.That(info!.NumberOfProcessingAttempts, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void RecordFailure_increments_attempt_count()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        storage.RecordFailure("msg-1", new Exception("first"), new ContextBag());
+        storage.RecordFailure("msg-1", new Exception("second"), new ContextBag());
+        storage.RecordFailure("msg-1", new Exception("third"), new ContextBag());
+
+        Assert.That(storage.TryGetFailureInfo("msg-1", out var info), Is.True);
+        Assert.That(info!.NumberOfProcessingAttempts, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void RecordFailure_preserves_latest_exception()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+        var latestException = new InvalidOperationException("latest");
+
+        storage.RecordFailure("msg-1", new Exception("first"), new ContextBag());
+        storage.RecordFailure("msg-1", latestException, new ContextBag());
+
+        storage.TryGetFailureInfo("msg-1", out var info);
+        Assert.That(info!.Exception, Is.SameAs(latestException));
+    }
+
+    [Test]
+    public void TryGetFailureInfo_returns_false_for_unknown_message()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        Assert.That(storage.TryGetFailureInfo("unknown", out var info), Is.False);
+        Assert.That(info, Is.Null);
+    }
+
+    [Test]
+    public void ClearFailure_removes_entry()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        storage.RecordFailure("msg-1", new Exception("fail"), new ContextBag());
+        storage.ClearFailure("msg-1");
+
+        Assert.That(storage.TryGetFailureInfo("msg-1", out _), Is.False);
+    }
+
+    [Test]
+    public void ClearFailure_is_idempotent()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        Assert.DoesNotThrow(() => storage.ClearFailure("nonexistent"));
+    }
+
+    [Test]
+    public void Separate_messages_are_independent()
+    {
+        var storage = new InMemoryFailureInfoStorage(TimeProvider.System);
+
+        storage.RecordFailure("msg-1", new Exception("a"), new ContextBag());
+        storage.RecordFailure("msg-2", new Exception("b"), new ContextBag());
+
+        storage.TryGetFailureInfo("msg-1", out var info1);
+        storage.TryGetFailureInfo("msg-2", out var info2);
+
+        Assert.That(info1!.Exception.Message, Is.EqualTo("a"));
+        Assert.That(info2!.Exception.Message, Is.EqualTo("b"));
+    }
+
+    [Test]
+    public void Sweep_removes_stale_entries()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var storage = new InMemoryFailureInfoStorage(fakeTime);
+
+        storage.RecordFailure("msg-1", new Exception("fail"), new ContextBag());
+
+        // Advance past TTL (1 min) + sweep interval (30s)
+        fakeTime.Advance(TimeSpan.FromMinutes(2));
+
+        // RecordFailure triggers sweep
+        storage.RecordFailure("msg-2", new Exception("trigger"), new ContextBag());
+
+        Assert.That(storage.TryGetFailureInfo("msg-1", out _), Is.False);
+        Assert.That(storage.TryGetFailureInfo("msg-2", out _), Is.True);
+    }
+
+    [Test]
+    public void Sweep_does_not_remove_fresh_entries()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var storage = new InMemoryFailureInfoStorage(fakeTime);
+
+        storage.RecordFailure("msg-1", new Exception("fail"), new ContextBag());
+
+        // Advance past sweep interval but not past TTL
+        fakeTime.Advance(TimeSpan.FromSeconds(35));
+
+        storage.RecordFailure("msg-2", new Exception("trigger"), new ContextBag());
+
+        Assert.That(storage.TryGetFailureInfo("msg-1", out _), Is.True);
+    }
+
+    [Test]
+    public void Sweep_does_not_run_before_interval()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var storage = new InMemoryFailureInfoStorage(fakeTime);
+
+        storage.RecordFailure("msg-1", new Exception("fail"), new ContextBag());
+
+        // Advance past TTL but not past sweep interval from last sweep
+        fakeTime.Advance(TimeSpan.FromSeconds(20));
+
+        storage.RecordFailure("msg-2", new Exception("trigger"), new ContextBag());
+
+        // msg-1 should still be there because sweep hasn't run
+        Assert.That(storage.TryGetFailureInfo("msg-1", out _), Is.True);
+    }
+}

--- a/src/Tests/MqConnectionPoolAdditionalTests.cs
+++ b/src/Tests/MqConnectionPoolAdditionalTests.cs
@@ -1,0 +1,121 @@
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using System.Threading;
+using System.Threading.Tasks;
+using IBM.WMQ;
+using NUnit.Framework;
+
+[TestFixture]
+[Category("RequiresBroker")]
+public class MqConnectionPoolAdditionalTests
+{
+    static readonly NServiceBus.Logging.ILog log = NServiceBus.Logging.LogManager.GetLogger<MqConnectionPoolAdditionalTests>();
+
+    [OneTimeSetUp]
+    public void Setup() => BrokerRequirement.Verify();
+
+    MqConnectionPool CreatePool(int maxSize = 2) => new(
+        log,
+        () => new MqConnection(
+            NServiceBus.Logging.LogManager.GetLogger<MqConnection>(),
+            TestBrokerConnection.Connect(),
+            name => name,
+            (_, _) => { },
+            100),
+        maxSize);
+
+    [Test]
+    public async Task Return_makes_connection_available_for_next_Rent()
+    {
+        var pool = CreatePool(maxSize: 1);
+
+        var conn = pool.Rent();
+        pool.Return(conn);
+
+        var same = pool.Rent();
+        Assert.That(same, Is.SameAs(conn));
+
+        pool.Return(same);
+        await pool.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Rent_creates_up_to_maxSize_connections()
+    {
+        var pool = CreatePool(maxSize: 2);
+
+        var conn1 = pool.Rent();
+        var conn2 = pool.Rent();
+
+        Assert.That(conn2, Is.Not.SameAs(conn1));
+
+        pool.Return(conn1);
+        pool.Return(conn2);
+        await pool.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DisposeAsync_disconnects_pooled_connections()
+    {
+        var pool = CreatePool(maxSize: 1);
+
+        var conn = pool.Rent();
+        pool.Return(conn);
+
+        await pool.DisposeAsync().ConfigureAwait(false);
+
+        // Connection should be disconnected — renting from a disposed pool
+        // still works (pool doesn't track disposed state) but the old
+        // connection was cleaned up
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task Rent_after_Return_reuses_connection()
+    {
+        var pool = CreatePool(maxSize: 2);
+
+        var conn1 = pool.Rent();
+        var conn2 = pool.Rent();
+        pool.Return(conn1);
+        pool.Return(conn2);
+
+        var reused1 = pool.Rent();
+        var reused2 = pool.Rent();
+
+        Assert.That(new[] { conn1, conn2 }, Does.Contain(reused1));
+        Assert.That(new[] { conn1, conn2 }, Does.Contain(reused2));
+
+        pool.Return(reused1);
+        pool.Return(reused2);
+        await pool.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task Discard_reduces_pool_size_allowing_new_creation()
+    {
+        var creationCount = 0;
+        var pool = new MqConnectionPool(
+            log,
+            () =>
+            {
+                Interlocked.Increment(ref creationCount);
+                return new MqConnection(
+                    NServiceBus.Logging.LogManager.GetLogger<MqConnection>(),
+                    TestBrokerConnection.Connect(),
+                    name => name,
+                    (_, _) => { },
+                    100);
+            },
+            maxSize: 1);
+
+        var conn1 = pool.Rent();
+        pool.Discard(conn1);
+
+        var conn2 = pool.Rent();
+        Assert.That(creationCount, Is.EqualTo(2));
+
+        pool.Return(conn2);
+        await pool.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Tests/MqPropertyNameEncoderTests.cs
+++ b/src/Tests/MqPropertyNameEncoderTests.cs
@@ -15,6 +15,11 @@ public class MqPropertyNameEncoderTests
     [TestCase("has space", "has_x0020space")]
     [TestCase("a.b-c_d", "a_x002Eb_x002Dc__d")]
     [TestCase("", "")]
+    [TestCase("_", "__")]
+    [TestCase("__", "____")]
+    [TestCase("a\0b", "a_x0000b")]
+    [TestCase("tab\there", "tab_x0009here")]
+    [TestCase("_x0041", "__x0041")]
     public void Encode(string input, string expected)
     {
         Assert.That(encoder.Encode(input), Is.EqualTo(expected));
@@ -26,6 +31,12 @@ public class MqPropertyNameEncoderTests
     [TestCase("a_x002Eb_x002Dc__d", "a.b-c_d")]
     [TestCase("", "")]
     [TestCase("a_b", "a_b")]
+    [TestCase("__", "_")]
+    [TestCase("____", "__")]
+    [TestCase("_x0000", "\0")]
+    [TestCase("trailing_", "trailing_")]
+    [TestCase("_xZZZZ", "_xZZZZ")]
+    [TestCase("_x00", "_x00")]
     public void Decode(string input, string expected)
     {
         Assert.That(encoder.Decode(input), Is.EqualTo(expected));
@@ -57,5 +68,21 @@ public class MqPropertyNameEncoderTests
         var encoded = encoder.Encode(original);
         var decoded = encoder.Decode(encoded);
         Assert.That(decoded, Is.EqualTo(original));
+    }
+
+    [Test]
+    public void Encode_caches_results()
+    {
+        var result1 = encoder.Encode("NServiceBus.MessageId");
+        var result2 = encoder.Encode("NServiceBus.MessageId");
+        Assert.That(result1, Is.SameAs(result2));
+    }
+
+    [Test]
+    public void Decode_caches_results()
+    {
+        var result1 = encoder.Decode("NServiceBus_x002EMessageId");
+        var result2 = encoder.Decode("NServiceBus_x002EMessageId");
+        Assert.That(result1, Is.SameAs(result2));
     }
 }

--- a/src/Tests/NServiceBus.Transport.IBMMQ.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.IBMMQ.Tests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="GitHubActionsTestLogger" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit.Analyzers" />

--- a/src/Transport/FailureInfoStorage/InMemoryFailureInfoStorage.cs
+++ b/src/Transport/FailureInfoStorage/InMemoryFailureInfoStorage.cs
@@ -2,21 +2,21 @@ namespace NServiceBus.Transport.IBMMQ;
 
 using System.Collections.Concurrent;
 
-sealed class InMemoryFailureInfoStorage : IFailureInfoStorage
+sealed class InMemoryFailureInfoStorage(TimeProvider timeProvider) : IFailureInfoStorage
 {
     // Entries only need to survive for the duration of the backout/re-delivery cycle
     // within the same process. Re-delivery from SYNCPOINT backout is near-instant (the
     // message is already on the queue), so 1 minute is sufficient. A longer TTL would
     // keep potentially large ContextBag object graphs alive unnecessarily.
-    static readonly long EntryTtlMs = (long)TimeSpan.FromMinutes(1).TotalMilliseconds;
-    static readonly long SweepIntervalMs = (long)TimeSpan.FromSeconds(30).TotalMilliseconds;
+    static readonly TimeSpan EntryTtl = TimeSpan.FromMinutes(1);
+    static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(30);
 
     readonly ConcurrentDictionary<string, (FailureRecord Record, long UpdatedAt)> failures = new();
-    long lastSweepAt = Environment.TickCount64;
+    long lastSweepAt = timeProvider.GetTimestamp();
 
     public void RecordFailure(string messageId, Exception exception, Extensibility.ContextBag context)
     {
-        var now = Environment.TickCount64;
+        var now = timeProvider.GetTimestamp();
 
         failures.AddOrUpdate(
             messageId,
@@ -46,10 +46,10 @@ sealed class InMemoryFailureInfoStorage : IFailureInfoStorage
 
     void SweepStaleEntries()
     {
-        var now = Environment.TickCount64;
+        var now = timeProvider.GetTimestamp();
         var previousSweep = Interlocked.Read(ref lastSweepAt);
 
-        if (now - previousSweep < SweepIntervalMs)
+        if (timeProvider.GetElapsedTime(previousSweep, now) < SweepInterval)
         {
             return;
         }
@@ -60,11 +60,11 @@ sealed class InMemoryFailureInfoStorage : IFailureInfoStorage
             return;
         }
 
-        var cutoff = now - EntryTtlMs;
+        var cutoffTimestamp = now - (long)(EntryTtl.TotalSeconds * timeProvider.TimestampFrequency);
 
         foreach (var kvp in failures)
         {
-            if (kvp.Value.UpdatedAt < cutoff)
+            if (kvp.Value.UpdatedAt < cutoffTimestamp)
             {
                 failures.TryRemove(kvp.Key, out _);
             }

--- a/src/Transport/IBMMQTransportInfrastructure.cs
+++ b/src/Transport/IBMMQTransportInfrastructure.cs
@@ -120,7 +120,8 @@ sealed class IBMMQTransportInfrastructure : TransportInfrastructure, IAsyncDispo
 
         if (transactionMode == TransportTransactionMode.SendsAtomicWithReceive)
         {
-            services.AddSingleton<IFailureInfoStorage>(new InMemoryFailureInfoStorage());
+            services.AddSingleton(TimeProvider.System);
+            services.AddSingleton<IFailureInfoStorage, InMemoryFailureInfoStorage>();
         }
 
         services


### PR DESCRIPTION
Follow-up to:

- #44

Adds tests for types that had no dedicated coverage and exercises edge cases in existing tests.

- **InMemoryFailureInfoStorage** refactored to `TimeProvider` for deterministic sweep testing
- **DestinationCache** LRU eviction, promotion, dispose behavior
- **MqPropertyNameEncoder** encoding edge cases (null char, lone underscore, invalid hex sequences)
- **IBMMQMessageConverter** round-trip tests including empty headers and empty body
- **MqConnectionPool** rent/return/discard lifecycle