### PR TITLE
Add Check for secrets step to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           --health-retries 10
           --health-start-period 30s
     steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:


### PR DESCRIPTION
Backport of main

## Summary
- Adds the `Check for secrets` step as the first step of the `build` job in `.github/workflows/ci.yml`
- Required by `repo-integrity-action`'s `CheckForSecrets` test, which is currently failing on PR #56 (GitHubSync update for `release-1.0`)
- This is the minimal subset of the fix already merged to `main` via #58 (which bundled many unrelated cleanups)

## Test plan
- [x] Code Analysis check passes on this PR