### PR TITLE
Allow version ranges based on multple segments

### DIFF
--- a/src/Transport/NServiceBus.Transport.IBMMQ.csproj
+++ b/src/Transport/NServiceBus.Transport.IBMMQ.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
+    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" AutomaticVersionRangeSegments="3" />
     <PackageReference Include="NServiceBus" Version="10.1.3" />
   </ItemGroup>
 

--- a/src/msbuild/ConvertToVersionRange.cs
+++ b/src/msbuild/ConvertToVersionRange.cs
@@ -35,18 +35,39 @@ public class ConvertToVersionRange : Task
             }
 
             var version = reference.GetMetadata(VersionProperty);
-            var match = Regex.Match(version, @"^\d+");
+            // Strip any prerelease suffix (e.g. "1.0.0-alpha.2") before extracting segments.
+            var versionCore = Regex.Match(version, @"^[\d.]+").Value;
+            var segments = Regex.Matches(versionCore, @"\d+");
 
-            if (match.Value.Equals(string.Empty, StringComparison.Ordinal))
+            if (segments.Count == 0)
             {
                 Log.LogError("Reference '{0}' with version '{1}' is not valid for automatic version range conversion. Fix the version or exclude the reference from conversion by setting 'AutomaticVersionRange=\"false\"' on the reference.", reference.ItemSpec, version);
                 success = false;
                 continue;
             }
 
-            var nextMajor = Convert.ToInt32(match.Value) + 1;
+            // AutomaticVersionRangeSegments controls which segment is bumped to form the upper bound.
+            // Default 1 (SemVer: bump major). For vendors that don't follow SemVer — e.g. IBM MQ's
+            // V.R.M.F scheme — set to 3 to bump the "Modification" segment (9.4.5 -> 9.4.6,
+            // 9.4.0.12 -> 9.4.1).
+            var segmentsMetadata = reference.GetMetadata("AutomaticVersionRangeSegments");
+            var segmentCount = 1;
+            if (!string.IsNullOrEmpty(segmentsMetadata) && (!int.TryParse(segmentsMetadata, out segmentCount) || segmentCount < 1))
+            {
+                Log.LogError("Reference '{0}' has invalid AutomaticVersionRangeSegments value '{1}'. Must be a positive integer.", reference.ItemSpec, segmentsMetadata);
+                success = false;
+                continue;
+            }
 
-            var versionRange = $"[{version}, {nextMajor}.0.0)";
+            var effectiveCount = Math.Min(segmentCount, segments.Count);
+            var parts = new string[effectiveCount];
+            for (var i = 0; i < effectiveCount; i++)
+            {
+                parts[i] = segments[i].Value;
+            }
+            parts[effectiveCount - 1] = (Convert.ToInt32(parts[effectiveCount - 1]) + 1).ToString();
+
+            var versionRange = $"[{version}, {string.Join(".", parts)})";
             reference.SetMetadata(VersionProperty, versionRange);
         }
 


### PR DESCRIPTION
## Summary

IBM MQ does not follow SemVer. Its V.R.M.F scheme only guarantees compatibility within the first three segments (V.R.M), so capping the automatic upper bound at the next major could allow consumers to resolve to a Modification release that IBM does not guarantee wire-compatible with the one the transport was built against.

This change adds an `AutomaticVersionRangeSegments="N"` metadata attribute on a `PackageReference`. It controls which segment the automatic upper bound bumps:

- Default stays at `1` (SemVer: bump major)
- For `IBMMQDotnetClient` we set it to `3` so `9.4.5` ships as `[9.4.5, 9.4.6)` and a `9.4.0.12`-style fixpack would ship as `[9.4.0.12, 9.4.1)`

## Notes

- `AutomaticVersionRanges.targets` disables itself when CPM is enabled, so on this branch alone (CPM still active) the new attribute is a no-op
- Combine with #74 (CPM removal) to see the feature actually applied to the transport package nuspec
- Prerelease version suffixes (e.g. `1.0.0-alpha.2`) are handled — the task strips the suffix before extracting segments
