### PR TITLE
Update NServiceBus to 10.1.3 to resolve CVE-2026-33116

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,11 +10,11 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="NServiceBus" Version="10.1.0" />
-    <PackageVersion Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus" Version="10.1.3" />
+    <PackageVersion Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.3" />
     <PackageVersion Include="NServiceBus.PerformanceTests.Sources" Version="1.0.0-alpha.2" />
     <PackageVersion Include="NServiceBus.Testing" Version="10.0.1" />
-    <PackageVersion Include="NServiceBus.TransportTests.Sources" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus.TransportTests.Sources" Version="10.1.3" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
Resolves:

- https://github.com/Particular/NServiceBus.Transport.IBMMQ/issues/69
- https://github.com/Particular/NServiceBus.Transport.IBMMQ/issues/67

```
error NU1903: Warning As Error: Package 'System.Security.Cryptography.Xml' 10.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3x6-4m5h-cxqf [/home/runner/work/NServiceBus.Transport.IBMMQ/NServiceBus.Transport.IBMMQ/src/NServiceBus.Transport.IBMMQ.slnx]
```

See https://github.com/advisories/GHSA-37gx-xxp4-5rgx