### PR TITLE
Add UseNonPersistentDeliveryMode SendOptions

### DIFF
--- a/src/AcceptanceTests/When_requesting_non_persistent_delivery.cs
+++ b/src/AcceptanceTests/When_requesting_non_persistent_delivery.cs
@@ -1,0 +1,71 @@
+namespace NServiceBus.AcceptanceTests;
+
+using AcceptanceTesting;
+using EndpointTemplates;
+using NUnit.Framework;
+
+public class When_requesting_non_persistent_delivery : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_flag_message_as_non_durable()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Receiver>(b => b.When((session, ctx) =>
+            {
+                var options = new SendOptions();
+
+                options.RouteToThisEndpoint();
+                options.UseNonPersistentDeliveryMode();
+
+                return session.Send(new Message(), options);
+            }))
+            .Done(c => c.MessageReceived)
+            .Run().ConfigureAwait(false);
+
+        Assert.That(context.NonDurableHeaderPresent, Is.True);
+    }
+
+    [Test]
+    public async Task Should_not_flag_message_as_non_durable_by_default()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Receiver>(b => b.When((session, ctx) =>
+            {
+                var options = new SendOptions();
+
+                options.RouteToThisEndpoint();
+
+                return session.Send(new Message(), options);
+            }))
+            .Done(c => c.MessageReceived)
+            .Run().ConfigureAwait(false);
+
+        Assert.That(context.NonDurableHeaderPresent, Is.False);
+    }
+
+    class Receiver : EndpointConfigurationBuilder
+    {
+        public Receiver() => EndpointSetup<DefaultServer>();
+
+        class MyMessageHandler(Context testContext) : IHandleMessages<Message>
+        {
+            public Task Handle(Message message, IMessageHandlerContext context)
+            {
+                testContext.NonDurableHeaderPresent = context.MessageHeaders.ContainsKey(Headers.NonDurableMessage);
+                testContext.MessageReceived = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class Message : IMessage
+    {
+    }
+
+    class Context : ScenarioContext
+    {
+        public bool MessageReceived { get; set; }
+
+        public bool NonDurableHeaderPresent { get; set; }
+    }
+}

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,6 +1,15 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Transport.IBMMQ.Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Transport.IBMMQ.PerformanceTests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Transport.IBMMQ.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
+namespace NServiceBus
+{
+    public static class NonPersistentDeliveryModeExtensions
+    {
+        public static void UseNonPersistentDeliveryMode(this NServiceBus.PublishOptions options) { }
+        public static void UseNonPersistentDeliveryMode(this NServiceBus.ReplyOptions options) { }
+        public static void UseNonPersistentDeliveryMode(this NServiceBus.SendOptions options) { }
+    }
+}
 namespace NServiceBus.Transport.IBMMQ
 {
     public sealed class IBMMQTransport : NServiceBus.Transport.TransportDefinition

--- a/src/Tests/NonPersistentDeliveryModeExtensionsTests.cs
+++ b/src/Tests/NonPersistentDeliveryModeExtensionsTests.cs
@@ -1,0 +1,62 @@
+#pragma warning disable PS0024 // "I" in IBMMQ is from IBM, not an interface prefix
+namespace NServiceBus.Transport.IBMMQ.Tests;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class NonPersistentDeliveryModeExtensionsTests
+{
+    [Test]
+    public void SendOptions_sets_NonDurableMessage_header()
+    {
+        var options = new SendOptions();
+
+        options.UseNonPersistentDeliveryMode();
+
+        Assert.That(options.GetHeaders()[Headers.NonDurableMessage], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public void PublishOptions_sets_NonDurableMessage_header()
+    {
+        var options = new PublishOptions();
+
+        options.UseNonPersistentDeliveryMode();
+
+        Assert.That(options.GetHeaders()[Headers.NonDurableMessage], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public void ReplyOptions_sets_NonDurableMessage_header()
+    {
+        var options = new ReplyOptions();
+
+        options.UseNonPersistentDeliveryMode();
+
+        Assert.That(options.GetHeaders()[Headers.NonDurableMessage], Is.EqualTo(bool.TrueString));
+    }
+
+    [Test]
+    public void SendOptions_throws_on_null()
+    {
+        SendOptions options = null;
+
+        Assert.Throws<ArgumentNullException>(() => options.UseNonPersistentDeliveryMode());
+    }
+
+    [Test]
+    public void PublishOptions_throws_on_null()
+    {
+        PublishOptions options = null;
+
+        Assert.Throws<ArgumentNullException>(() => options.UseNonPersistentDeliveryMode());
+    }
+
+    [Test]
+    public void ReplyOptions_throws_on_null()
+    {
+        ReplyOptions options = null;
+
+        Assert.Throws<ArgumentNullException>(() => options.UseNonPersistentDeliveryMode());
+    }
+}

--- a/src/Transport/Sending/NonPersistentDeliveryModeExtensions.cs
+++ b/src/Transport/Sending/NonPersistentDeliveryModeExtensions.cs
@@ -1,0 +1,37 @@
+namespace NServiceBus;
+
+/// <summary>
+/// Adds extension methods for the relevant ExtendableOptions classes.
+/// </summary>
+public static class NonPersistentDeliveryModeExtensions
+{
+    /// <summary>
+    /// Uses the non-persistent delivery mode to send the message.
+    /// </summary>
+    public static void UseNonPersistentDeliveryMode(this SendOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.SetHeader(Headers.NonDurableMessage, bool.TrueString);
+    }
+
+    /// <summary>
+    /// Uses the non-persistent delivery mode to publish the message.
+    /// </summary>
+    public static void UseNonPersistentDeliveryMode(this PublishOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.SetHeader(Headers.NonDurableMessage, bool.TrueString);
+    }
+
+    /// <summary>
+    /// Uses the non-persistent delivery mode to send the reply.
+    /// </summary>
+    public static void UseNonPersistentDeliveryMode(this ReplyOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.SetHeader(Headers.NonDurableMessage, bool.TrueString);
+    }
+}


### PR DESCRIPTION
When releasing this, make sure [this documentation PR](https://github.com/Particular/docs.particular.net/pull/8201) is merged.

Exposes a per-message toggle so callers can opt into non-persistent delivery without resorting to raw header manipulation, matching the API shape offered by the RabbitMQ transport. Wires into the existing Headers.NonDurableMessage pipeline already honored by the message converter.